### PR TITLE
provide `name` and `version` in `LanguageServer` constructor

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     "context": "..",
     "args": {
       // Update 'VARIANT' to pick a Python version: 3, 3.6, 3.7, 3.8, 3.9
-      "VARIANT": "3",
+      "VARIANT": "3.10",
       // Options
       "INSTALL_NODE": "true",
       "NODE_VERSION": "lts/*"
@@ -30,7 +30,7 @@
       "-S",
       "-l 180"
     ],
-    "python.linting.flake8Path": "flake518",
+    "python.linting.flake8Path": "flake8",
     "python.linting.mypyPath": "mypy",
     "python.linting.pylintPath": "pylint",
     "python.linting.pylintArgs": [
@@ -61,7 +61,9 @@
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": true
     },
-    "eslint.validate": ["typescript"]
+    "eslint.validate": [
+      "typescript"
+    ]
   },
   // Add the IDs of extensions you want installed when the container is created.
   "extensions": [

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -141,7 +141,7 @@ jobs:
         id: server-flake8
         if: always()
         working-directory: ./grizzly-ls
-        run: python3 -m flake518
+        run: python3 -m flake8
 
       - name: 'server: black'
         id: server-black

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -20,9 +20,9 @@ jobs:
         python-version: ['3.8', '3.9', '3.10']
         runs-on: ['ubuntu-latest']
         include:
-          - python-version: '3.x'
+          - python-version: '3.10'
             runs-on: windows-latest
-          - python-version: '3.x'
+          - python-version: '3.10'
             runs-on: macos-latest
 
     steps:
@@ -35,7 +35,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
 
       - name: install dependencies
         id: pip
@@ -69,8 +68,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
-          cache: 'pip'
+          python-version: '3.10'
 
       - uses: actions/setup-node@v3
         with:
@@ -112,8 +110,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
-          cache: 'pip'
+          python-version: '3.10'
 
       - uses: actions/setup-node@v3
         with:
@@ -174,7 +171,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.10'
 
       - name: install python dependencies
         id: pip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: get latest tag
         uses: actions-ecosystem/action-get-latest-tag@v1
@@ -79,7 +81,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.10'
           cache: 'pip'
 
       - name: create temporary release tag

--- a/grizzly-ls/pyproject.toml
+++ b/grizzly-ls/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = 'setuptools.build_meta'
 name = 'grizzly-loadtester-ls'
 description = 'LSP server implementation for grizzly-loadtester load scenario development'
 dependencies = [
-    'pygls',
+    'pygls >=0.13.0',
     'behave'
 ]
 readme = 'README.md'
@@ -54,7 +54,7 @@ dev = [
     'pytest-timeout',
     'coverage[toml]',
     'pylint',
-    'flake518',
+    'flake8-pyproject',
     'black',
     'mypy',
     'grizzly-loadtester',

--- a/grizzly-ls/src/grizzly_ls/__init__.py
+++ b/grizzly-ls/src/grizzly_ls/__init__.py
@@ -1,0 +1,7 @@
+from importlib.metadata import version, PackageNotFoundError
+
+
+try:
+    __version__ = version('grizzly-loadtester-ls')
+except PackageNotFoundError:
+    __version__ = 'unknown'

--- a/grizzly-ls/src/grizzly_ls/server.py
+++ b/grizzly-ls/src/grizzly_ls/server.py
@@ -53,6 +53,7 @@ from behave.i18n import languages
 
 from .text import Normalizer, get_step_parts, clean_help
 from .utils import create_step_normalizer, load_step_registry
+from . import __version__
 
 
 class GrizzlyLanguageServer(LanguageServer):
@@ -76,7 +77,7 @@ class GrizzlyLanguageServer(LanguageServer):
         super().show_message(message, msg_type=msg_type)  # type: ignore
 
     def __init__(self, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:
-        super().__init__(*args, **kwargs)  # type: ignore
+        super().__init__(name='grizzly-ls', version=__version__, *args, **kwargs)  # type: ignore
 
         self.behave_steps = {}
         self.steps = {}
@@ -251,6 +252,8 @@ class GrizzlyLanguageServer(LanguageServer):
             help_text: Optional[str] = None
             current_line = self._current_line(params.text_document.uri, params.position)
             keyword, step = get_step_parts(current_line)
+
+            self.logger.debug(f'{keyword=}, {step=}')
 
             if step is None or keyword is None or keyword.lower() not in self.steps:
                 return None

--- a/grizzly-ls/tests/fixtures.py
+++ b/grizzly-ls/tests/fixtures.py
@@ -47,13 +47,13 @@ class LspFixture:
             except:
                 pass
 
-        self.server = GrizzlyLanguageServer(asyncio.new_event_loop())  # type: ignore
+        self.server = GrizzlyLanguageServer(loop=asyncio.new_event_loop())  # type: ignore
         self._server_thread = Thread(
             target=start, args=(self.server, cstdio, sstdout), daemon=True
         )
         self._server_thread.start()
 
-        self.client = LanguageServer(asyncio.new_event_loop())
+        self.client = LanguageServer(loop=asyncio.new_event_loop())
         self._client_thread = Thread(
             target=start, args=(self.client, sstdio, cstdout), daemon=True
         )

--- a/grizzly-ls/tests/test_server.py
+++ b/grizzly-ls/tests/test_server.py
@@ -40,12 +40,15 @@ from pygls.lsp.types.basic_structures import (
 from behave.matchers import ParseMatcher
 
 from .fixtures import LspFixture
+from grizzly_ls import __version__
 
 
 class TestGrizzlyLanguageServer:
     def test___init__(self, lsp_fixture: LspFixture) -> None:
         server = lsp_fixture.server
 
+        assert server.name == 'grizzly-ls'
+        assert server.version == __version__
         assert server.steps == {}
         assert server.keywords == []
         assert server.keyword_alias == {
@@ -314,6 +317,7 @@ class TestGrizzlyLanguageServer:
             'Then save {target:ResponseTarget} as "{content_type:ContentType}" in "{variable}" for "{count}" {grammar:UserGramaticalNumber}',
         )
         actual = sorted(server._normalize_step_expression(step))
+        print('\n'.join(actual))
         assert actual == sorted(
             [
                 'Then save payload as "undefined" in "" for "" user',
@@ -332,6 +336,10 @@ class TestGrizzlyLanguageServer:
                 'Then save payload as "plain" in "" for "" users',
                 'Then save metadata as "plain" in "" for "" user',
                 'Then save metadata as "plain" in "" for "" users',
+                'Then save metadata as "multipart_form_data" in "" for "" user',
+                'Then save metadata as "multipart_form_data" in "" for "" users',
+                'Then save payload as "multipart_form_data" in "" for "" user',
+                'Then save payload as "multipart_form_data" in "" for "" users',
             ]
         )
 


### PR DESCRIPTION
update pygls version.
pin devcontainer to python 3.10, there are dependencies that does not support 3.11 yet. changed from flake518 to flake8-pyproject, to get a pyproject flake8 configuration compatible wrapper. fixed tests.

closes Biometria-se/grizzly#168.