### PR TITLE
return snippet strings for step expressions containing variables

### DIFF
--- a/client/vscode/tests/completion.test.ts
+++ b/client/vscode/tests/completion.test.ts
@@ -131,6 +131,27 @@ describe('Should do completion on steps', () => {
         actual.items.forEach((item) => {
             expect(item.kind).to.be.equal(vscode.CompletionItemKind.Function);
         });
+
+        const actualInsertText = actual.items.map((item) => {
+            if (item.insertText instanceof vscode.SnippetString) {
+                return item.insertText.value;
+            } else {
+                return item.insertText;
+            }
+        });
+        expected.forEach((e) => {
+            const parts: string[] = [];
+            let index = 1;
+            for (const p of e.split('""')) {
+                if (p === undefined || p.length < 1) {
+                    continue;
+                }
+                parts.push(p);
+                parts.push(`"$${index++}"`);
+            }
+            e = parts.join('');
+            expect(actualInsertText).to.contain(e);
+        });
     });
 
     it('Complete steps, keyword `Then` step `save response metadata "hello"`', async () => {

--- a/grizzly-ls/tests/test_server.py
+++ b/grizzly-ls/tests/test_server.py
@@ -216,13 +216,14 @@ class TestGrizzlyLanguageServer:
                     == 'save response metadata "hello" that matches "" in variable ""'
                 ):
                     assert (
-                        suggested_step.insert_text == ' that matches "" in variable ""'
+                        suggested_step.insert_text
+                        == ' that matches "$1" in variable "$2"'
                     )
                 elif (
                     suggested_step.label
                     == 'save response metadata "hello" in variable ""'
                 ):
-                    assert suggested_step.insert_text == ' in variable ""'
+                    assert suggested_step.insert_text == ' in variable "$1"'
                 else:
                     raise AssertionError(
                         f'"{suggested_step.label}" was an unexpected suggested step'


### PR DESCRIPTION
this fixes Biometria-se/grizzly#155, so the cursor is placed where user input is needed, and one can tab through all variables.