### PR TITLE
complete variable names

### DIFF
--- a/grizzly-ls/pyproject.toml
+++ b/grizzly-ls/pyproject.toml
@@ -138,7 +138,7 @@ skip-string-normalization = true
 
 [tool.flake8]
 max-line-length = 180
-ignore = ['E722', 'W503', 'E402', 'F405', 'F403']
+ignore = ['E722', 'W503', 'E402', 'F405', 'F403', 'E203']
 exclude = ['.git', '__pycache__', 'docs', 'build', 'dist']
 
 [tool.mypy]

--- a/grizzly-ls/src/grizzly_ls/server.py
+++ b/grizzly-ls/src/grizzly_ls/server.py
@@ -490,7 +490,7 @@ class GrizzlyLanguageServer(LanguageServer):
                     # only insert the part of the step that has not already been written, up until last space, since vscode
                     # seems to insert text word wise
                     insert_text = matched_step.replace(expression, '')
-                    if not insert_text.startswith(' '):
+                    if not insert_text.startswith(' ') and insert_text.strip().count(' ') < 1:
                         try:
                             _, insert_text = matched_step.rsplit(' ', 1)
                         except:
@@ -507,6 +507,8 @@ class GrizzlyLanguageServer(LanguageServer):
                 # if typed expression ends with whitespace, do not insert text starting with a whitespace
                 if expression[-1] == ' ' and expression[-2] != ' ' and insert_text[0] == ' ':
                     insert_text = insert_text[1:]
+
+                self.logger.debug(f'{expression=}, {insert_text=}, {matched_step=}')
 
                 if '""' in insert_text:
                     snippet_matches = re.finditer(

--- a/grizzly-ls/src/grizzly_ls/server.py
+++ b/grizzly-ls/src/grizzly_ls/server.py
@@ -55,7 +55,9 @@ from .utils import create_step_normalizer, load_step_registry
 from . import __version__
 
 
-VARIABLE_PATTERN = re.compile(r'(.*ask for value of variable "([^"]*)"$|.*value for variable "([^"]*)" is ".*?"$)')
+VARIABLE_PATTERN = re.compile(
+    r'(.*ask for value of variable "([^"]*)"$|.*value for variable "([^"]*)" is ".*?"$)'
+)
 
 
 class GrizzlyLanguageServer(LanguageServer):
@@ -77,7 +79,9 @@ class GrizzlyLanguageServer(LanguageServer):
 
     markup_kind: MarkupKind
 
-    def show_message(self, message: str, msg_type: Optional[MessageType] = MessageType.Info) -> None:
+    def show_message(
+        self, message: str, msg_type: Optional[MessageType] = MessageType.Info
+    ) -> None:
         super().show_message(message, msg_type=msg_type)  # type: ignore
 
     def __init__(self, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:
@@ -105,10 +109,18 @@ class GrizzlyLanguageServer(LanguageServer):
                 self.logger.error(error_message)
                 self.show_message(error_message, msg_type=MessageType.Error)
 
-            root_path = Path(unquote(url2pathname(urlparse(params.root_uri).path))) if params.root_uri is not None else Path(cast(str, params.root_path))
+            root_path = (
+                Path(unquote(url2pathname(urlparse(params.root_uri).path)))
+                if params.root_uri is not None
+                else Path(cast(str, params.root_path))
+            )
 
             # fugly as hell
-            if not root_path.exists() and str(root_path)[0:1] == sep and str(root_path)[2] == ':':
+            if (
+                not root_path.exists()
+                and str(root_path)[0:1] == sep
+                and str(root_path)[2] == ':'
+            ):
                 root_path = Path(str(root_path)[1:])
 
             self.root_path = root_path
@@ -124,8 +136,12 @@ class GrizzlyLanguageServer(LanguageServer):
             has_venv = virtual_environment.exists()
 
             if not has_venv:
-                self.logger.debug(f'creating virtual environment: {virtual_environment}')
-                self.show_message('creating virtual environment for language server, this could take a while')
+                self.logger.debug(
+                    f'creating virtual environment: {virtual_environment}'
+                )
+                self.show_message(
+                    'creating virtual environment for language server, this could take a while'
+                )
                 venv_create(str(virtual_environment))
 
             if platform.system() == 'Windows':  # pragma: no cover
@@ -198,7 +214,9 @@ class GrizzlyLanguageServer(LanguageServer):
             items: List[CompletionItem] = []
             document = self.workspace.get_document(params.text_document.uri)
 
-            self.logger.debug(f'{line=}, {params.position=}, trigger=\'{line[:params.position.character]}\'')
+            self.logger.debug(
+                f'{line=}, {params.position=}, trigger=\'{line[:params.position.character]}\''
+            )
 
             if line[: params.position.character].rstrip().endswith('{{'):
                 items = self._complete_variable_name(line, document, params.position)
@@ -233,7 +251,14 @@ class GrizzlyLanguageServer(LanguageServer):
 
             self.logger.debug(f'{keyword=}, {step=}')
 
-            if step is None or keyword is None or (keyword.lower() not in self.steps and keyword not in self.keyword_any):
+            if (
+                step is None
+                or keyword is None
+                or (
+                    keyword.lower() not in self.steps
+                    and keyword not in self.keyword_any
+                )
+            ):
                 return None
 
             start = current_line.index(keyword)
@@ -246,7 +271,12 @@ class GrizzlyLanguageServer(LanguageServer):
 
             if 'Args:' in help_text:
                 pre, post = help_text.split('Args:', 1)
-                text = '\n'.join([self._format_arg_line(arg_line) for arg_line in post.strip().split('\n')])
+                text = '\n'.join(
+                    [
+                        self._format_arg_line(arg_line)
+                        for arg_line in post.strip().split('\n')
+                    ]
+                )
 
                 help_text = f'{pre}Args:\n\n{text}\n'
 
@@ -310,7 +340,9 @@ class GrizzlyLanguageServer(LanguageServer):
         except ValueError:
             return f'* {line}'
 
-    def _complete_keyword(self, keyword: Optional[str], document: Document) -> List[CompletionItem]:
+    def _complete_keyword(
+        self, keyword: Optional[str], document: Document
+    ) -> List[CompletionItem]:
         items: List[CompletionItem] = []
         if len(document.source.strip()) < 1:
             keywords = ['Feature']
@@ -362,7 +394,7 @@ class GrizzlyLanguageServer(LanguageServer):
         document: Document,
         position: Position,
     ) -> List[CompletionItem]:
-        ## find `Scenario:` before current position
+        # find `Scenario:` before current position
         lines = document.source.splitlines()
         before_lines = reversed(lines[0 : position.line])
 
@@ -379,10 +411,26 @@ class GrizzlyLanguageServer(LanguageServer):
                         insert_text = None
                     else:
                         prefix = '' if line[: position.character].endswith(' ') else ' '
-                        suffix = '"' if not line.rstrip().endswith('"') and line.count('"') % 2 != 0 else ''
-                        affix = '' if line[position.character :].strip().startswith('}}') else '}}'
-                        affix_suffix = '' if not line[position.character :].startswith('}}') and affix != '}}' else ' '
-                        insert_text = f'{prefix}{variable_name}{affix_suffix}{affix}{suffix}'
+                        suffix = (
+                            '"'
+                            if not line.rstrip().endswith('"')
+                            and line.count('"') % 2 != 0
+                            else ''
+                        )
+                        affix = (
+                            ''
+                            if line[position.character :].strip().startswith('}}')
+                            else '}}'
+                        )
+                        affix_suffix = (
+                            ''
+                            if not line[position.character :].startswith('}}')
+                            and affix != '}}'
+                            else ' '
+                        )
+                        insert_text = (
+                            f'{prefix}{variable_name}{affix_suffix}{affix}{suffix}'
+                        )
 
                     self.logger.debug(f'{line=}, {variable_name=}, {insert_text=}')
 
@@ -424,7 +472,15 @@ class GrizzlyLanguageServer(LanguageServer):
         expression: Optional[str],
     ) -> List[CompletionItem]:
         if keyword in self.keyword_any:
-            steps = list(set([re.sub(r'"[^"]*"', '""', step) for keyword_steps in self.steps.values() for step in keyword_steps]))
+            steps = list(
+                set(
+                    [
+                        re.sub(r'"[^"]*"', '""', step)
+                        for keyword_steps in self.steps.values()
+                        for step in keyword_steps
+                    ]
+                )
+            )
         else:
             steps = self.steps.get(keyword.lower(), [])
 
@@ -468,15 +524,23 @@ class GrizzlyLanguageServer(LanguageServer):
                 matched_steps_2 = set(filter(lambda s: expression_shell in s, steps))  # type: ignore
 
                 # 3. "fuzzy" matching
-                matched_steps_3 = set(get_close_matches(expression_shell, steps, len(steps), 0.6))
+                matched_steps_3 = set(
+                    get_close_matches(expression_shell, steps, len(steps), 0.6)
+                )
 
             # keep order so that 1. matches comes before 2. matches etc.
             matched_steps_container: Dict[str, CompletionItem] = {}
 
-            input_matches = list(re.finditer(r'"([^"]*)"', expression, flags=re.MULTILINE))
+            input_matches = list(
+                re.finditer(r'"([^"]*)"', expression, flags=re.MULTILINE)
+            )
 
-            for matched_step in itertools.chain(matched_steps_1, matched_steps_2, matched_steps_3):
-                output_matches = list(re.finditer(r'"([^"]*)"', matched_step, flags=re.MULTILINE))
+            for matched_step in itertools.chain(
+                matched_steps_1, matched_steps_2, matched_steps_3
+            ):
+                output_matches = list(
+                    re.finditer(r'"([^"]*)"', matched_step, flags=re.MULTILINE)
+                )
 
                 # suggest step with already entetered variables in their correct place
                 if input_matches and output_matches:
@@ -490,7 +554,10 @@ class GrizzlyLanguageServer(LanguageServer):
                     # only insert the part of the step that has not already been written, up until last space, since vscode
                     # seems to insert text word wise
                     insert_text = matched_step.replace(expression, '')
-                    if not insert_text.startswith(' ') and insert_text.strip().count(' ') < 1:
+                    if (
+                        not insert_text.startswith(' ')
+                        and insert_text.strip().count(' ') < 1
+                    ):
                         try:
                             _, insert_text = matched_step.rsplit(' ', 1)
                         except:
@@ -505,7 +572,11 @@ class GrizzlyLanguageServer(LanguageServer):
                     preselect = True
 
                 # if typed expression ends with whitespace, do not insert text starting with a whitespace
-                if expression[-1] == ' ' and expression[-2] != ' ' and insert_text[0] == ' ':
+                if (
+                    expression[-1] == ' '
+                    and expression[-2] != ' '
+                    and insert_text[0] == ' '
+                ):
                     insert_text = insert_text[1:]
 
                 self.logger.debug(f'{expression=}, {insert_text=}, {matched_step=}')
@@ -638,7 +709,11 @@ class GrizzlyLanguageServer(LanguageServer):
         step_help = self.help.get(step.strip(), None)
 
         if step_help is None:
-            possible_help = {possible_step: help for possible_step, help in self.help.items() if possible_step.startswith(step)}
+            possible_help = {
+                possible_step: help
+                for possible_step, help in self.help.items()
+                if possible_step.startswith(step)
+            }
 
             if len(possible_help) < 1:
                 return None

--- a/grizzly-ls/src/grizzly_ls/server.py
+++ b/grizzly-ls/src/grizzly_ls/server.py
@@ -74,9 +74,7 @@ class GrizzlyLanguageServer(LanguageServer):
 
     markup_kind: MarkupKind
 
-    def show_message(
-        self, message: str, msg_type: Optional[MessageType] = MessageType.Info
-    ) -> None:
+    def show_message(self, message: str, msg_type: Optional[MessageType] = MessageType.Info) -> None:
         super().show_message(message, msg_type=msg_type)  # type: ignore
 
     def __init__(self, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> None:
@@ -104,18 +102,10 @@ class GrizzlyLanguageServer(LanguageServer):
                 self.logger.error(error_message)
                 self.show_message(error_message, msg_type=MessageType.Error)
 
-            root_path = (
-                Path(unquote(url2pathname(urlparse(params.root_uri).path)))
-                if params.root_uri is not None
-                else Path(cast(str, params.root_path))
-            )
+            root_path = Path(unquote(url2pathname(urlparse(params.root_uri).path))) if params.root_uri is not None else Path(cast(str, params.root_path))
 
             # fugly as hell
-            if (
-                not root_path.exists()
-                and str(root_path)[0:1] == sep
-                and str(root_path)[2] == ':'
-            ):
+            if not root_path.exists() and str(root_path)[0:1] == sep and str(root_path)[2] == ':':
                 root_path = Path(str(root_path)[1:])
 
             self.root_path = root_path
@@ -131,12 +121,8 @@ class GrizzlyLanguageServer(LanguageServer):
             has_venv = virtual_environment.exists()
 
             if not has_venv:
-                self.logger.debug(
-                    f'creating virtual environment: {virtual_environment}'
-                )
-                self.show_message(
-                    'creating virtual environment for language server, this could take a while'
-                )
+                self.logger.debug(f'creating virtual environment: {virtual_environment}')
+                self.show_message('creating virtual environment for language server, this could take a while')
                 venv_create(str(virtual_environment))
 
             if platform.system() == 'Windows':  # pragma: no cover
@@ -205,17 +191,20 @@ class GrizzlyLanguageServer(LanguageServer):
             assert self.steps is not None, 'no steps in inventory'
 
             line = self._current_line(params.text_document.uri, params.position)
-            keyword, step = get_step_parts(line)
 
             items: List[CompletionItem] = []
             document = self.workspace.get_document(params.text_document.uri)
 
-            self.logger.debug(f'{keyword=}, {step=}, {self.keywords=}')
-
-            if keyword is not None and keyword in self.keywords:
-                items = self._complete_step(keyword, step)
+            if line[params.position.character - 1 : params.position.character + 1] == '{{':
+                items = self._complete_variable_name(line, document, params.position)
             else:
-                items = self._complete_keyword(keyword, document)
+                keyword, text = get_step_parts(line)
+                self.logger.debug(f'{keyword=}, {text=}, {self.keywords=}')
+
+                if keyword is not None and keyword in self.keywords:
+                    items = self._complete_step(keyword, text)
+                else:
+                    items = self._complete_keyword(keyword, document)
 
             # self.logger.debug(f'completion: {items=}')
 
@@ -239,14 +228,7 @@ class GrizzlyLanguageServer(LanguageServer):
 
             self.logger.debug(f'{keyword=}, {step=}')
 
-            if (
-                step is None
-                or keyword is None
-                or (
-                    keyword.lower() not in self.steps
-                    and keyword not in self.keyword_any
-                )
-            ):
+            if step is None or keyword is None or (keyword.lower() not in self.steps and keyword not in self.keyword_any):
                 return None
 
             start = current_line.index(keyword)
@@ -259,12 +241,7 @@ class GrizzlyLanguageServer(LanguageServer):
 
             if 'Args:' in help_text:
                 pre, post = help_text.split('Args:', 1)
-                text = '\n'.join(
-                    [
-                        self._format_arg_line(arg_line)
-                        for arg_line in post.strip().split('\n')
-                    ]
-                )
+                text = '\n'.join([self._format_arg_line(arg_line) for arg_line in post.strip().split('\n')])
 
                 help_text = f'{pre}Args:\n\n{text}\n'
 
@@ -328,9 +305,7 @@ class GrizzlyLanguageServer(LanguageServer):
         except ValueError:
             return f'* {line}'
 
-    def _complete_keyword(
-        self, keyword: Optional[str], document: Document
-    ) -> List[CompletionItem]:
+    def _complete_keyword(self, keyword: Optional[str], document: Document) -> List[CompletionItem]:
         items: List[CompletionItem] = []
         if len(document.source.strip()) < 1:
             keywords = ['Feature']
@@ -378,21 +353,70 @@ class GrizzlyLanguageServer(LanguageServer):
 
         return items
 
+    def _complete_variable_name(
+        self,
+        line: str,
+        document: Document,
+        position: Position,
+    ) -> List[CompletionItem]:
+        # extract variable names in current scenario
+        variable_pattern = re.compile(r'(.*ask for value of variable "([^"]*)"$|.*value for variable "([^"]*)" is ".*?"$)')
+
+        ## find `scenario:` before current position
+        lines = document.source.splitlines()
+        before_lines = reversed(lines[0 : position.line])
+
+        variable_names: List[Tuple[str, Optional[str]]] = []
+
+        for before_line in before_lines:
+            match = variable_pattern.match(before_line)
+
+            if match:
+                variable_name = match.group(2) or match.group(3)
+                insert_text = f'{variable_name} }}}}" {line[position.character+1:]}'.strip()
+
+                # @TODO: insert text should replace all "" with "$1", ... "$N"
+
+                if variable_name is not None:
+                    variable_names.append(
+                        (
+                            variable_name,
+                            insert_text,
+                        )
+                    )
+            elif 'Scenario:' in before_line:
+                break
+
+        return [
+            CompletionItem(
+                label=variable_name,
+                kind=CompletionItemKind.Variable,
+                tags=None,
+                detail=None,
+                documentation=None,
+                deprecated=False,
+                preselect=None,
+                sort_text=None,
+                filter_text=None,
+                insert_text=insert_text,
+                insert_text_format=None,
+                insert_text_mode=None,
+                text_edit=None,
+                additional_text_edits=None,
+                commit_characters=None,
+                command=None,
+                data=None,
+            )
+            for variable_name, insert_text in variable_names
+        ]
+
     def _complete_step(
         self,
         keyword: str,
         expression: Optional[str],
     ) -> List[CompletionItem]:
         if keyword in self.keyword_any:
-            steps = list(
-                set(
-                    [
-                        re.sub(r'"[^"]*"', '""', step)
-                        for keyword_steps in self.steps.values()
-                        for step in keyword_steps
-                    ]
-                )
-            )
+            steps = list(set([re.sub(r'"[^"]*"', '""', step) for keyword_steps in self.steps.values() for step in keyword_steps]))
         else:
             steps = self.steps.get(keyword.lower(), [])
 
@@ -436,23 +460,15 @@ class GrizzlyLanguageServer(LanguageServer):
                 matched_steps_2 = set(filter(lambda s: expression_shell in s, steps))  # type: ignore
 
                 # 3. "fuzzy" matching
-                matched_steps_3 = set(
-                    get_close_matches(expression_shell, steps, len(steps), 0.6)
-                )
+                matched_steps_3 = set(get_close_matches(expression_shell, steps, len(steps), 0.6))
 
             # keep order so that 1. matches comes before 2. matches etc.
             matched_steps_container: Dict[str, CompletionItem] = {}
 
-            input_matches = list(
-                re.finditer(r'"([^"]*)"', expression, flags=re.MULTILINE)
-            )
+            input_matches = list(re.finditer(r'"([^"]*)"', expression, flags=re.MULTILINE))
 
-            for matched_step in itertools.chain(
-                matched_steps_1, matched_steps_2, matched_steps_3
-            ):
-                output_matches = list(
-                    re.finditer(r'"([^"]*)"', matched_step, flags=re.MULTILINE)
-                )
+            for matched_step in itertools.chain(matched_steps_1, matched_steps_2, matched_steps_3):
+                output_matches = list(re.finditer(r'"([^"]*)"', matched_step, flags=re.MULTILINE))
 
                 # suggest step with already entetered variables in their correct place
                 if input_matches and output_matches:
@@ -481,11 +497,7 @@ class GrizzlyLanguageServer(LanguageServer):
                     preselect = True
 
                 # if typed expression ends with whitespace, do not insert text starting with a whitespace
-                if (
-                    expression[-1] == ' '
-                    and expression[-2] != ' '
-                    and insert_text[0] == ' '
-                ):
+                if expression[-1] == ' ' and expression[-2] != ' ' and insert_text[0] == ' ':
                     insert_text = insert_text[1:]
 
                 if '""' in insert_text:
@@ -616,11 +628,7 @@ class GrizzlyLanguageServer(LanguageServer):
         step_help = self.help.get(step.strip(), None)
 
         if step_help is None:
-            possible_help = {
-                possible_step: help
-                for possible_step, help in self.help.items()
-                if possible_step.startswith(step)
-            }
+            possible_help = {possible_step: help for possible_step, help in self.help.items() if possible_step.startswith(step)}
 
             if len(possible_help) < 1:
                 return None

--- a/grizzly-ls/tests/test_server.py
+++ b/grizzly-ls/tests/test_server.py
@@ -69,8 +69,16 @@ class TestGrizzlyLanguageServer:
     def test__format_arg_line(self, lsp_fixture: LspFixture) -> None:
         server = lsp_fixture.server
 
-        assert server._format_arg_line('hello_world (bool): foo bar description of argument') == '* hello_world `bool`: foo bar description of argument'
-        assert server._format_arg_line('hello: strange stuff (bool)') == '* hello: strange stuff (bool)'
+        assert (
+            server._format_arg_line(
+                'hello_world (bool): foo bar description of argument'
+            )
+            == '* hello_world `bool`: foo bar description of argument'
+        )
+        assert (
+            server._format_arg_line('hello: strange stuff (bool)')
+            == '* hello: strange stuff (bool)'
+        )
 
     def test__complete_keyword(self, lsp_fixture: LspFixture) -> None:
         grizzly_project = Path(__file__) / '..' / '..' / '..' / 'tests' / 'project'
@@ -82,7 +90,9 @@ class TestGrizzlyLanguageServer:
             source='',
         )
 
-        assert normalize_completion_item(server._complete_keyword(None, document), CompletionItemKind.Keyword) == [
+        assert normalize_completion_item(
+            server._complete_keyword(None, document), CompletionItemKind.Keyword
+        ) == [
             'Feature',
         ]
 
@@ -91,7 +101,9 @@ class TestGrizzlyLanguageServer:
             source='Feature:',
         )
 
-        assert normalize_completion_item(server._complete_keyword(None, document), CompletionItemKind.Keyword) == [
+        assert normalize_completion_item(
+            server._complete_keyword(None, document), CompletionItemKind.Keyword
+        ) == [
             'Background',
             'Scenario',
         ]
@@ -103,7 +115,9 @@ class TestGrizzlyLanguageServer:
 ''',
         )
 
-        assert normalize_completion_item(server._complete_keyword(None, document), CompletionItemKind.Keyword) == [
+        assert normalize_completion_item(
+            server._complete_keyword(None, document), CompletionItemKind.Keyword
+        ) == [
             'And',
             'Background',
             'But',
@@ -122,7 +136,9 @@ class TestGrizzlyLanguageServer:
 ''',
         )
 
-        assert normalize_completion_item(server._complete_keyword(None, document), CompletionItemKind.Keyword) == [
+        assert normalize_completion_item(
+            server._complete_keyword(None, document), CompletionItemKind.Keyword
+        ) == [
             'And',
             'But',
             'Given',
@@ -131,24 +147,32 @@ class TestGrizzlyLanguageServer:
             'When',
         ]
 
-        assert normalize_completion_item(server._complete_keyword('EN', document), CompletionItemKind.Keyword) == [
+        assert normalize_completion_item(
+            server._complete_keyword('EN', document), CompletionItemKind.Keyword
+        ) == [
             'Given',
             'Scenario',
             'Then',
             'When',
         ]
 
-        assert normalize_completion_item(server._complete_keyword('Giv', document), CompletionItemKind.Keyword) == [
+        assert normalize_completion_item(
+            server._complete_keyword('Giv', document), CompletionItemKind.Keyword
+        ) == [
             'Given',
         ]
 
-    def test__complete_step(self, lsp_fixture: LspFixture, caplog: LogCaptureFixture) -> None:
+    def test__complete_step(
+        self, lsp_fixture: LspFixture, caplog: LogCaptureFixture
+    ) -> None:
         grizzly_project = Path(__file__) / '..' / '..' / '..' / 'tests' / 'project'
         server = lsp_fixture.server
         server._compile_inventory(grizzly_project.resolve(), 'project')
 
         with caplog.at_level(logging.DEBUG):
-            matched_steps = normalize_completion_item(server._complete_step('Given', 'variable'), CompletionItemKind.Function)
+            matched_steps = normalize_completion_item(
+                server._complete_step('Given', 'variable'), CompletionItemKind.Function
+            )
 
             for expected_step in [
                 'set context variable "" to ""',
@@ -159,7 +183,9 @@ class TestGrizzlyLanguageServer:
             ]:
                 assert expected_step in matched_steps
 
-            matched_steps = normalize_completion_item(server._complete_step('Then', 'save'), CompletionItemKind.Function)
+            matched_steps = normalize_completion_item(
+                server._complete_step('Then', 'save'), CompletionItemKind.Function
+            )
             for expected_step in [
                 'save response metadata "" in variable ""',
                 'save response payload "" in variable ""',
@@ -174,8 +200,12 @@ class TestGrizzlyLanguageServer:
             ]:
                 assert expected_step in matched_steps
 
-            suggested_steps = server._complete_step('Then', 'save response metadata "hello"')
-            matched_steps = normalize_completion_item(suggested_steps, CompletionItemKind.Function)
+            suggested_steps = server._complete_step(
+                'Then', 'save response metadata "hello"'
+            )
+            matched_steps = normalize_completion_item(
+                suggested_steps, CompletionItemKind.Function
+            )
 
             for expected_step in [
                 'save response metadata "hello" in variable ""',
@@ -184,14 +214,27 @@ class TestGrizzlyLanguageServer:
                 assert expected_step in matched_steps
 
             for suggested_step in suggested_steps:
-                if suggested_step.label == 'save response metadata "hello" that matches "" in variable ""':
-                    assert suggested_step.insert_text == ' that matches "$1" in variable "$2"'
-                elif suggested_step.label == 'save response metadata "hello" in variable ""':
+                if (
+                    suggested_step.label
+                    == 'save response metadata "hello" that matches "" in variable ""'
+                ):
+                    assert (
+                        suggested_step.insert_text
+                        == ' that matches "$1" in variable "$2"'
+                    )
+                elif (
+                    suggested_step.label
+                    == 'save response metadata "hello" in variable ""'
+                ):
                     assert suggested_step.insert_text == ' in variable "$1"'
                 else:
-                    raise AssertionError(f'"{suggested_step.label}" was an unexpected suggested step')
+                    raise AssertionError(
+                        f'"{suggested_step.label}" was an unexpected suggested step'
+                    )
 
-            matched_steps = normalize_completion_item(server._complete_step('When', None), CompletionItemKind.Function)
+            matched_steps = normalize_completion_item(
+                server._complete_step('When', None), CompletionItemKind.Function
+            )
 
             for expected_step in [
                 'condition "" with name "" is true, execute these tasks',
@@ -205,7 +248,9 @@ class TestGrizzlyLanguageServer:
             ]:
                 assert expected_step in matched_steps
 
-            matched_steps = normalize_completion_item(server._complete_step('When', 'response '), CompletionItemKind.Function)
+            matched_steps = normalize_completion_item(
+                server._complete_step('When', 'response '), CompletionItemKind.Function
+            )
 
             for expected_step in [
                 'response time percentile ""% is greater than "" milliseconds fail scenario',
@@ -241,12 +286,17 @@ class TestGrizzlyLanguageServer:
                 assert expected_step in matched_steps
 
             matched_steps = normalize_completion_item(
-                server._complete_step('Given', 'a user of type "RestApi" with weight "1" load'),
+                server._complete_step(
+                    'Given', 'a user of type "RestApi" with weight "1" load'
+                ),
                 CompletionItemKind.Function,
             )
 
             assert len(matched_steps) == 1
-            assert matched_steps[0] == 'a user of type "RestApi" with weight "1" load testing ""'
+            assert (
+                matched_steps[0]
+                == 'a user of type "RestApi" with weight "1" load testing ""'
+            )
 
             actual_completed_steps = server._complete_step('And', 'repeat for "1" it')
 
@@ -255,7 +305,9 @@ class TestGrizzlyLanguageServer:
                 CompletionItemKind.Function,
             )
 
-            assert sorted(matched_steps) == sorted(['repeat for "1" iterations', 'repeat for "1" iteration'])
+            assert sorted(matched_steps) == sorted(
+                ['repeat for "1" iterations', 'repeat for "1" iteration']
+            )
 
             matched_insert_text = normalize_completion_item(
                 actual_completed_steps,
@@ -272,7 +324,9 @@ class TestGrizzlyLanguageServer:
                 CompletionItemKind.Function,
             )
 
-            assert sorted(matched_steps) == sorted(['repeat for "1" iterations', 'repeat for "1" iteration'])
+            assert sorted(matched_steps) == sorted(
+                ['repeat for "1" iterations', 'repeat for "1" iteration']
+            )
 
             matched_insert_text = normalize_completion_item(
                 actual_completed_steps,
@@ -289,7 +343,9 @@ class TestGrizzlyLanguageServer:
                 CompletionItemKind.Function,
             )
 
-            assert sorted(matched_steps) == sorted(['repeat for "1" iterations', 'repeat for "1" iteration'])
+            assert sorted(matched_steps) == sorted(
+                ['repeat for "1" iterations', 'repeat for "1" iteration']
+            )
 
             matched_insert_text = normalize_completion_item(
                 actual_completed_steps,
@@ -299,17 +355,23 @@ class TestGrizzlyLanguageServer:
 
             assert sorted(matched_insert_text) == sorted(['iteration', 'iterations'])
 
-            actual_completed_steps = server._complete_step('Then', 'parse date "{{ datetime.now() }}" ')
+            actual_completed_steps = server._complete_step(
+                'Then', 'parse date "{{ datetime.now() }}" '
+            )
             assert len(actual_completed_steps) == 1
             actual_completed_step = actual_completed_steps[0]
             assert actual_completed_step.insert_text == 'and save in variable "$1"'
 
-            actual_completed_steps = server._complete_step('Then', 'parse date "{{ datetime.now() }}"')
+            actual_completed_steps = server._complete_step(
+                'Then', 'parse date "{{ datetime.now() }}"'
+            )
             assert len(actual_completed_steps) == 1
             actual_completed_step = actual_completed_steps[0]
             assert actual_completed_step.insert_text == ' and save in variable "$1"'
 
-    def test__normalize_step_expression(self, lsp_fixture: LspFixture, mocker: MockerFixture, caplog: LogCaptureFixture) -> None:
+    def test__normalize_step_expression(
+        self, lsp_fixture: LspFixture, mocker: MockerFixture, caplog: LogCaptureFixture
+    ) -> None:
         mocker.patch('parse.Parser.__init__', return_value=None)
         server = lsp_fixture.server
 
@@ -338,7 +400,9 @@ class TestGrizzlyLanguageServer:
             ]
         )
 
-        step = ParseMatcher(noop, 'send from {from_node:MessageDirection} to {to_node:MessageDirection}')
+        step = ParseMatcher(
+            noop, 'send from {from_node:MessageDirection} to {to_node:MessageDirection}'
+        )
 
         assert sorted(server._normalize_step_expression(step)) == sorted(
             [
@@ -414,7 +478,11 @@ class TestGrizzlyLanguageServer:
             ]
         )
 
-        assert sorted(server._normalize_step_expression('{method:Method} {direction:Direction} endpoint "{endpoint:s}"')) == sorted(
+        assert sorted(
+            server._normalize_step_expression(
+                '{method:Method} {direction:Direction} endpoint "{endpoint:s}"'
+            )
+        ) == sorted(
             [
                 'send to endpoint ""',
                 'send from endpoint ""',
@@ -445,16 +513,24 @@ class TestGrizzlyLanguageServer:
                 ]
             )
         assert len(caplog.messages) == 1
-        assert caplog.messages[-1] == "unhandled type: variable='{test:Unknown}', variable_type='Unknown'"
+        assert (
+            caplog.messages[-1]
+            == "unhandled type: variable='{test:Unknown}', variable_type='Unknown'"
+        )
 
         assert show_message_mock.call_count == 1
         args, kwargs = show_message_mock.call_args_list[-1]
         assert len(args) == 1
-        assert args[0] == "unhandled type: variable='{test:Unknown}', variable_type='Unknown'"
+        assert (
+            args[0]
+            == "unhandled type: variable='{test:Unknown}', variable_type='Unknown'"
+        )
         assert len(kwargs) == 1
         assert kwargs.get('msg_type', None) == 1
 
-    def test__compile_inventory(self, lsp_fixture: LspFixture, caplog: LogCaptureFixture) -> None:
+    def test__compile_inventory(
+        self, lsp_fixture: LspFixture, caplog: LogCaptureFixture
+    ) -> None:
         server = lsp_fixture.server
 
         assert server.steps == {}
@@ -494,7 +570,9 @@ class TestGrizzlyLanguageServer:
         assert 'Given' in server.keywords  # - " -
         assert 'When' in server.keywords
 
-    def test__current_line(self, lsp_fixture: LspFixture, mocker: MockerFixture) -> None:
+    def test__current_line(
+        self, lsp_fixture: LspFixture, mocker: MockerFixture
+    ) -> None:
         server = lsp_fixture.server
 
         mocker.patch.object(server.lsp, 'workspace', Workspace('', None))
@@ -510,13 +588,38 @@ class TestGrizzlyLanguageServer:
             ),
         )
 
-        assert server._current_line('file://test.feature', Position(line=0, character=0)).strip() == 'Feature:'
-        assert server._current_line('file://test.feature', Position(line=1, character=543)).strip() == 'Scenario: test'
-        assert server._current_line('file://test.feature', Position(line=2, character=435)).strip() == 'Then hello world!'
-        assert server._current_line('file://test.feature', Position(line=3, character=534)).strip() == 'But foo bar'
+        assert (
+            server._current_line(
+                'file://test.feature', Position(line=0, character=0)
+            ).strip()
+            == 'Feature:'
+        )
+        assert (
+            server._current_line(
+                'file://test.feature', Position(line=1, character=543)
+            ).strip()
+            == 'Scenario: test'
+        )
+        assert (
+            server._current_line(
+                'file://test.feature', Position(line=2, character=435)
+            ).strip()
+            == 'Then hello world!'
+        )
+        assert (
+            server._current_line(
+                'file://test.feature', Position(line=3, character=534)
+            ).strip()
+            == 'But foo bar'
+        )
 
         with pytest.raises(IndexError) as ie:
-            assert server._current_line('file://test.feature', Position(line=10, character=10)).strip() == 'Then hello world!'
+            assert (
+                server._current_line(
+                    'file://test.feature', Position(line=10, character=10)
+                ).strip()
+                == 'Then hello world!'
+            )
         assert str(ie.value) == 'list index out of range'
 
     def test__find_help(self, lsp_fixture: LspFixture, mocker: MockerFixture) -> None:
@@ -529,12 +632,20 @@ class TestGrizzlyLanguageServer:
             '"" bar': 'this is the help for foo bar parameterized',
         }
 
-        assert server._find_help('Then hello world') == 'this is the help for hello world'
+        assert (
+            server._find_help('Then hello world') == 'this is the help for hello world'
+        )
         assert server._find_help('asdfasdf') is None
         assert server._find_help('And hello') == 'this is the help for hello world'
-        assert server._find_help('And hello "world"') == 'this is the help for hello world parameterized'
+        assert (
+            server._find_help('And hello "world"')
+            == 'this is the help for hello world parameterized'
+        )
         assert server._find_help('But foo') == 'this is the help for foo bar'
-        assert server._find_help('But "foo" bar') == 'this is the help for foo bar parameterized'
+        assert (
+            server._find_help('But "foo" bar')
+            == 'this is the help for foo bar parameterized'
+        )
 
     class TestGrizzlyLangageServerFeatures:
         def _initialize(self, client: LanguageServer, root: Path) -> None:
@@ -576,7 +687,9 @@ class TestGrizzlyLanguageServer:
             finally:
                 logger.setLevel(level)
 
-        def _open(self, client: LanguageServer, path: Path, text: Optional[str] = None) -> None:
+        def _open(
+            self, client: LanguageServer, path: Path, text: Optional[str] = None
+        ) -> None:
             if text is None:
                 text = path.read_text()
 
@@ -593,7 +706,12 @@ class TestGrizzlyLanguageServer:
             )
 
         def _completion(
-            self, client: LanguageServer, path: Path, content: str, context: Optional[CompletionContext] = None, position: Optional[Position] = None
+            self,
+            client: LanguageServer,
+            path: Path,
+            content: str,
+            context: Optional[CompletionContext] = None,
+            position: Optional[Position] = None,
         ) -> Optional[CompletionList]:
             self._initialize(client, path)
 
@@ -701,7 +819,9 @@ class TestGrizzlyLanguageServer:
 
             assert 'Feature' not in server.keywords  # already used once in feature file
             assert 'Background' not in server.keywords  # - " -
-            assert 'And' in server.keywords  # just an alias for Given, but we need want it
+            assert (
+                'And' in server.keywords
+            )  # just an alias for Given, but we need want it
             assert 'Scenario' in server.keywords  # can be used multiple times
             assert 'Given' in server.keywords  # - " -
             assert 'When' in server.keywords
@@ -712,7 +832,14 @@ class TestGrizzlyLanguageServer:
             def filter_keyword_properties(
                 items: List[CompletionItem],
             ) -> List[Dict[str, Any]]:
-                return [{key: getattr(item, key) for key in item.__dir__() if key in ['label', 'kind']} for item in items]
+                return [
+                    {
+                        key: getattr(item, key)
+                        for key in item.__dir__()
+                        if key in ['label', 'kind']
+                    }
+                    for item in items
+                ]
 
             # partial match, keyword containing 'B'
             response = self._completion(
@@ -769,7 +896,9 @@ class TestGrizzlyLanguageServer:
             response = self._completion(client, lsp_fixture.datadir, '')
             assert response is not None
             assert not response.is_incomplete
-            unexpected_kinds = list(filter(lambda k: k != 14, map(lambda k: k.kind, response.items)))
+            unexpected_kinds = list(
+                filter(lambda k: k != 14, map(lambda k: k.kind, response.items))
+            )
             assert len(unexpected_kinds) == 0
             labels = list(map(lambda k: k.label, response.items))
             assert all([True if label is not None else False for label in labels])
@@ -842,7 +971,9 @@ class TestGrizzlyLanguageServer:
             assert 'a user of type "" with weight "" load testing ""' in labels
             assert 'a user of type "" load testing ""' in labels
 
-            response = self._completion(client, lsp_fixture.datadir, 'Then parse date "{{ datetime.now() }}"')
+            response = self._completion(
+                client, lsp_fixture.datadir, 'Then parse date "{{ datetime.now() }}"'
+            )
             assert response is not None
             assert not response.is_incomplete
 
@@ -853,10 +984,14 @@ class TestGrizzlyLanguageServer:
                 map(lambda s: s.insert_text, response.items),
             )
 
-            assert labels == ['parse date "{{ datetime.now() }}" and save in variable ""']
+            assert labels == [
+                'parse date "{{ datetime.now() }}" and save in variable ""'
+            ]
             assert insert_texts == [' and save in variable "$1"']
 
-        def test_completion_variable_names(self, lsp_fixture: LspFixture, caplog: LogCaptureFixture) -> None:
+        def test_completion_variable_names(
+            self, lsp_fixture: LspFixture, caplog: LogCaptureFixture
+        ) -> None:
             client = lsp_fixture.client
 
             content = '''Feature: test
@@ -875,9 +1010,13 @@ class TestGrizzlyLanguageServer:
             labels = list(
                 map(lambda s: s.label, response.items),
             )
-            insert_texts = list([s.insert_text for s in response.items if s.insert_text is not None])
+            insert_texts = list(
+                [s.insert_text for s in response.items if s.insert_text is not None]
+            )
 
-            assert sorted(insert_texts) == sorted([' price }}"', ' foo }}"', ' test }}"', ' bar }}"'])
+            assert sorted(insert_texts) == sorted(
+                [' price }}"', ' foo }}"', ' test }}"', ' bar }}"']
+            )
             assert sorted(labels) == sorted(['price', 'foo', 'test', 'bar'])
 
             content = '''Feature: test
@@ -908,40 +1047,67 @@ class TestGrizzlyLanguageServer:
 
         Then log message "{{ }}"'''
 
-            response = self._completion(client, lsp_fixture.datadir, content, position=Position(line=8, character=28))
+            response = self._completion(
+                client,
+                lsp_fixture.datadir,
+                content,
+                position=Position(line=8, character=28),
+            )
 
             assert response is not None
 
             labels = list(
                 map(lambda s: s.label, response.items),
             )
-            insert_texts = list([s.insert_text for s in response.items if s.insert_text is not None])
+            insert_texts = list(
+                [s.insert_text for s in response.items if s.insert_text is not None]
+            )
 
-            assert sorted(insert_texts) == sorted([' price }}"', ' foo }}"', ' test }}"', ' bar }}"'])
+            assert sorted(insert_texts) == sorted(
+                [' price }}"', ' foo }}"', ' test }}"', ' bar }}"']
+            )
             assert sorted(labels) == sorted(['price', 'foo', 'test', 'bar'])
 
-            response = self._completion(client, lsp_fixture.datadir, content, position=Position(line=17, character=28))
+            response = self._completion(
+                client,
+                lsp_fixture.datadir,
+                content,
+                position=Position(line=17, character=28),
+            )
 
             assert response is not None
 
             labels = list(
                 map(lambda s: s.label, response.items),
             )
-            insert_texts = list([s.insert_text for s in response.items if s.insert_text is not None])
+            insert_texts = list(
+                [s.insert_text for s in response.items if s.insert_text is not None]
+            )
 
-            assert sorted(insert_texts) == sorted([' weight }}', ' hello }}', ' test }}', ' world }}'])
+            assert sorted(insert_texts) == sorted(
+                [' weight }}', ' hello }}', ' test }}', ' world }}']
+            )
             assert sorted(labels) == sorted(['weight', 'hello', 'test', 'world'])
 
-            response = self._completion(client, lsp_fixture.datadir, content, position=Position(line=26, character=28))
+            response = self._completion(
+                client,
+                lsp_fixture.datadir,
+                content,
+                position=Position(line=26, character=28),
+            )
 
             assert response is not None
 
             labels = list(
                 map(lambda s: s.label, response.items),
             )
-            insert_texts = list([s.insert_text for s in response.items if s.insert_text is not None])
+            insert_texts = list(
+                [s.insert_text for s in response.items if s.insert_text is not None]
+            )
 
-            assert sorted(insert_texts) == sorted([' weight', ' hello', ' test', ' world'])
+            assert sorted(insert_texts) == sorted(
+                [' weight', ' hello', ' test', ' world']
+            )
             assert sorted(labels) == sorted(['weight', 'hello', 'test', 'world'])
 
             content = '''Feature: test
@@ -953,16 +1119,25 @@ class TestGrizzlyLanguageServer:
         And ask for value of variable "bar"
 
         Then parse date "{{" and save in variable ""'''
-            response = self._completion(client, lsp_fixture.datadir, content, position=Position(line=8, character=27))
+            response = self._completion(
+                client,
+                lsp_fixture.datadir,
+                content,
+                position=Position(line=8, character=27),
+            )
 
             assert response is not None
 
             labels = list(
                 map(lambda s: s.label, response.items),
             )
-            insert_texts = list([s.insert_text for s in response.items if s.insert_text is not None])
+            insert_texts = list(
+                [s.insert_text for s in response.items if s.insert_text is not None]
+            )
 
-            assert sorted(insert_texts) == sorted([' price }}', ' foo }}', ' test }}', ' bar }}'])
+            assert sorted(insert_texts) == sorted(
+                [' price }}', ' foo }}', ' test }}', ' bar }}']
+            )
             assert sorted(labels) == sorted(['price', 'foo', 'test', 'bar'])
 
             content = '''Feature: test
@@ -975,27 +1150,43 @@ class TestGrizzlyLanguageServer:
 
         Then send request "test/request.j2.json" with name "{{" to endpoint ""
         Then send request "{{}}" with name "" to endpoint ""'''
-            response = self._completion(client, lsp_fixture.datadir, content, position=Position(line=8, character=62))
+            response = self._completion(
+                client,
+                lsp_fixture.datadir,
+                content,
+                position=Position(line=8, character=62),
+            )
 
             assert response is not None
 
             labels = list(
                 map(lambda s: s.label, response.items),
             )
-            insert_texts = list([s.insert_text for s in response.items if s.insert_text is not None])
+            insert_texts = list(
+                [s.insert_text for s in response.items if s.insert_text is not None]
+            )
 
-            assert sorted(insert_texts) == sorted([' price }}', ' foo }}', ' test }}', ' bar }}'])
+            assert sorted(insert_texts) == sorted(
+                [' price }}', ' foo }}', ' test }}', ' bar }}']
+            )
             assert sorted(labels) == sorted(['price', 'foo', 'test', 'bar'])
 
             with caplog.at_level(logging.DEBUG):
-                response = self._completion(client, lsp_fixture.datadir, content, position=Position(line=9, character=29))
+                response = self._completion(
+                    client,
+                    lsp_fixture.datadir,
+                    content,
+                    position=Position(line=9, character=29),
+                )
 
             assert response is not None
 
             labels = list(
                 map(lambda s: s.label, response.items),
             )
-            insert_texts = list([s.insert_text for s in response.items if s.insert_text is not None])
+            insert_texts = list(
+                [s.insert_text for s in response.items if s.insert_text is not None]
+            )
 
             assert sorted(insert_texts) == sorted(
                 [
@@ -1010,7 +1201,9 @@ class TestGrizzlyLanguageServer:
         def test_hover(self, lsp_fixture: LspFixture) -> None:
             client = lsp_fixture.client
 
-            response = self._hover(client, lsp_fixture.datadir, Position(line=2, character=31))
+            response = self._hover(
+                client, lsp_fixture.datadir, Position(line=2, character=31)
+            )
 
             assert response is not None
             assert response.range is not None
@@ -1043,7 +1236,9 @@ Args:
 '''
             )
 
-            response = self._hover(client, lsp_fixture.datadir, Position(line=0, character=1))
+            response = self._hover(
+                client, lsp_fixture.datadir, Position(line=0, character=1)
+            )
 
             assert response is None
 
@@ -1067,7 +1262,9 @@ Args:
         def test_definition(self, lsp_fixture: LspFixture) -> None:
             client = lsp_fixture.client
 
-            response = self._definition(client, lsp_fixture.datadir, Position(line=2, character=30))
+            response = self._definition(
+                client, lsp_fixture.datadir, Position(line=2, character=30)
+            )
 
             assert response is None
 

--- a/grizzly-ls/tests/test_server.py
+++ b/grizzly-ls/tests/test_server.py
@@ -69,16 +69,8 @@ class TestGrizzlyLanguageServer:
     def test__format_arg_line(self, lsp_fixture: LspFixture) -> None:
         server = lsp_fixture.server
 
-        assert (
-            server._format_arg_line(
-                'hello_world (bool): foo bar description of argument'
-            )
-            == '* hello_world `bool`: foo bar description of argument'
-        )
-        assert (
-            server._format_arg_line('hello: strange stuff (bool)')
-            == '* hello: strange stuff (bool)'
-        )
+        assert server._format_arg_line('hello_world (bool): foo bar description of argument') == '* hello_world `bool`: foo bar description of argument'
+        assert server._format_arg_line('hello: strange stuff (bool)') == '* hello: strange stuff (bool)'
 
     def test__complete_keyword(self, lsp_fixture: LspFixture) -> None:
         grizzly_project = Path(__file__) / '..' / '..' / '..' / 'tests' / 'project'
@@ -90,9 +82,7 @@ class TestGrizzlyLanguageServer:
             source='',
         )
 
-        assert normalize_completion_item(
-            server._complete_keyword(None, document), CompletionItemKind.Keyword
-        ) == [
+        assert normalize_completion_item(server._complete_keyword(None, document), CompletionItemKind.Keyword) == [
             'Feature',
         ]
 
@@ -101,9 +91,7 @@ class TestGrizzlyLanguageServer:
             source='Feature:',
         )
 
-        assert normalize_completion_item(
-            server._complete_keyword(None, document), CompletionItemKind.Keyword
-        ) == [
+        assert normalize_completion_item(server._complete_keyword(None, document), CompletionItemKind.Keyword) == [
             'Background',
             'Scenario',
         ]
@@ -115,9 +103,7 @@ class TestGrizzlyLanguageServer:
 ''',
         )
 
-        assert normalize_completion_item(
-            server._complete_keyword(None, document), CompletionItemKind.Keyword
-        ) == [
+        assert normalize_completion_item(server._complete_keyword(None, document), CompletionItemKind.Keyword) == [
             'And',
             'Background',
             'But',
@@ -136,9 +122,7 @@ class TestGrizzlyLanguageServer:
 ''',
         )
 
-        assert normalize_completion_item(
-            server._complete_keyword(None, document), CompletionItemKind.Keyword
-        ) == [
+        assert normalize_completion_item(server._complete_keyword(None, document), CompletionItemKind.Keyword) == [
             'And',
             'But',
             'Given',
@@ -147,32 +131,24 @@ class TestGrizzlyLanguageServer:
             'When',
         ]
 
-        assert normalize_completion_item(
-            server._complete_keyword('EN', document), CompletionItemKind.Keyword
-        ) == [
+        assert normalize_completion_item(server._complete_keyword('EN', document), CompletionItemKind.Keyword) == [
             'Given',
             'Scenario',
             'Then',
             'When',
         ]
 
-        assert normalize_completion_item(
-            server._complete_keyword('Giv', document), CompletionItemKind.Keyword
-        ) == [
+        assert normalize_completion_item(server._complete_keyword('Giv', document), CompletionItemKind.Keyword) == [
             'Given',
         ]
 
-    def test__complete_step(
-        self, lsp_fixture: LspFixture, caplog: LogCaptureFixture
-    ) -> None:
+    def test__complete_step(self, lsp_fixture: LspFixture, caplog: LogCaptureFixture) -> None:
         grizzly_project = Path(__file__) / '..' / '..' / '..' / 'tests' / 'project'
         server = lsp_fixture.server
         server._compile_inventory(grizzly_project.resolve(), 'project')
 
         with caplog.at_level(logging.DEBUG):
-            matched_steps = normalize_completion_item(
-                server._complete_step('Given', 'variable'), CompletionItemKind.Function
-            )
+            matched_steps = normalize_completion_item(server._complete_step('Given', 'variable'), CompletionItemKind.Function)
 
             for expected_step in [
                 'set context variable "" to ""',
@@ -183,9 +159,7 @@ class TestGrizzlyLanguageServer:
             ]:
                 assert expected_step in matched_steps
 
-            matched_steps = normalize_completion_item(
-                server._complete_step('Then', 'save'), CompletionItemKind.Function
-            )
+            matched_steps = normalize_completion_item(server._complete_step('Then', 'save'), CompletionItemKind.Function)
             for expected_step in [
                 'save response metadata "" in variable ""',
                 'save response payload "" in variable ""',
@@ -200,12 +174,8 @@ class TestGrizzlyLanguageServer:
             ]:
                 assert expected_step in matched_steps
 
-            suggested_steps = server._complete_step(
-                'Then', 'save response metadata "hello"'
-            )
-            matched_steps = normalize_completion_item(
-                suggested_steps, CompletionItemKind.Function
-            )
+            suggested_steps = server._complete_step('Then', 'save response metadata "hello"')
+            matched_steps = normalize_completion_item(suggested_steps, CompletionItemKind.Function)
 
             for expected_step in [
                 'save response metadata "hello" in variable ""',
@@ -214,27 +184,14 @@ class TestGrizzlyLanguageServer:
                 assert expected_step in matched_steps
 
             for suggested_step in suggested_steps:
-                if (
-                    suggested_step.label
-                    == 'save response metadata "hello" that matches "" in variable ""'
-                ):
-                    assert (
-                        suggested_step.insert_text
-                        == ' that matches "$1" in variable "$2"'
-                    )
-                elif (
-                    suggested_step.label
-                    == 'save response metadata "hello" in variable ""'
-                ):
+                if suggested_step.label == 'save response metadata "hello" that matches "" in variable ""':
+                    assert suggested_step.insert_text == ' that matches "$1" in variable "$2"'
+                elif suggested_step.label == 'save response metadata "hello" in variable ""':
                     assert suggested_step.insert_text == ' in variable "$1"'
                 else:
-                    raise AssertionError(
-                        f'"{suggested_step.label}" was an unexpected suggested step'
-                    )
+                    raise AssertionError(f'"{suggested_step.label}" was an unexpected suggested step')
 
-            matched_steps = normalize_completion_item(
-                server._complete_step('When', None), CompletionItemKind.Function
-            )
+            matched_steps = normalize_completion_item(server._complete_step('When', None), CompletionItemKind.Function)
 
             for expected_step in [
                 'condition "" with name "" is true, execute these tasks',
@@ -248,9 +205,7 @@ class TestGrizzlyLanguageServer:
             ]:
                 assert expected_step in matched_steps
 
-            matched_steps = normalize_completion_item(
-                server._complete_step('When', 'response '), CompletionItemKind.Function
-            )
+            matched_steps = normalize_completion_item(server._complete_step('When', 'response '), CompletionItemKind.Function)
 
             for expected_step in [
                 'response time percentile ""% is greater than "" milliseconds fail scenario',
@@ -286,17 +241,12 @@ class TestGrizzlyLanguageServer:
                 assert expected_step in matched_steps
 
             matched_steps = normalize_completion_item(
-                server._complete_step(
-                    'Given', 'a user of type "RestApi" with weight "1" load'
-                ),
+                server._complete_step('Given', 'a user of type "RestApi" with weight "1" load'),
                 CompletionItemKind.Function,
             )
 
             assert len(matched_steps) == 1
-            assert (
-                matched_steps[0]
-                == 'a user of type "RestApi" with weight "1" load testing ""'
-            )
+            assert matched_steps[0] == 'a user of type "RestApi" with weight "1" load testing ""'
 
             actual_completed_steps = server._complete_step('And', 'repeat for "1" it')
 
@@ -305,9 +255,7 @@ class TestGrizzlyLanguageServer:
                 CompletionItemKind.Function,
             )
 
-            assert sorted(matched_steps) == sorted(
-                ['repeat for "1" iterations', 'repeat for "1" iteration']
-            )
+            assert sorted(matched_steps) == sorted(['repeat for "1" iterations', 'repeat for "1" iteration'])
 
             matched_insert_text = normalize_completion_item(
                 actual_completed_steps,
@@ -324,9 +272,7 @@ class TestGrizzlyLanguageServer:
                 CompletionItemKind.Function,
             )
 
-            assert sorted(matched_steps) == sorted(
-                ['repeat for "1" iterations', 'repeat for "1" iteration']
-            )
+            assert sorted(matched_steps) == sorted(['repeat for "1" iterations', 'repeat for "1" iteration'])
 
             matched_insert_text = normalize_completion_item(
                 actual_completed_steps,
@@ -343,9 +289,7 @@ class TestGrizzlyLanguageServer:
                 CompletionItemKind.Function,
             )
 
-            assert sorted(matched_steps) == sorted(
-                ['repeat for "1" iterations', 'repeat for "1" iteration']
-            )
+            assert sorted(matched_steps) == sorted(['repeat for "1" iterations', 'repeat for "1" iteration'])
 
             matched_insert_text = normalize_completion_item(
                 actual_completed_steps,
@@ -355,9 +299,17 @@ class TestGrizzlyLanguageServer:
 
             assert sorted(matched_insert_text) == sorted(['iteration', 'iterations'])
 
-    def test__normalize_step_expression(
-        self, lsp_fixture: LspFixture, mocker: MockerFixture, caplog: LogCaptureFixture
-    ) -> None:
+            actual_completed_steps = server._complete_step('Then', 'parse date "{{ datetime.now() }}" ')
+            assert len(actual_completed_steps) == 1
+            actual_completed_step = actual_completed_steps[0]
+            assert actual_completed_step.insert_text == 'and save in variable "$1"'
+
+            actual_completed_steps = server._complete_step('Then', 'parse date "{{ datetime.now() }}"')
+            assert len(actual_completed_steps) == 1
+            actual_completed_step = actual_completed_steps[0]
+            assert actual_completed_step.insert_text == ' and save in variable "$1"'
+
+    def test__normalize_step_expression(self, lsp_fixture: LspFixture, mocker: MockerFixture, caplog: LogCaptureFixture) -> None:
         mocker.patch('parse.Parser.__init__', return_value=None)
         server = lsp_fixture.server
 
@@ -386,9 +338,7 @@ class TestGrizzlyLanguageServer:
             ]
         )
 
-        step = ParseMatcher(
-            noop, 'send from {from_node:MessageDirection} to {to_node:MessageDirection}'
-        )
+        step = ParseMatcher(noop, 'send from {from_node:MessageDirection} to {to_node:MessageDirection}')
 
         assert sorted(server._normalize_step_expression(step)) == sorted(
             [
@@ -464,11 +414,7 @@ class TestGrizzlyLanguageServer:
             ]
         )
 
-        assert sorted(
-            server._normalize_step_expression(
-                '{method:Method} {direction:Direction} endpoint "{endpoint:s}"'
-            )
-        ) == sorted(
+        assert sorted(server._normalize_step_expression('{method:Method} {direction:Direction} endpoint "{endpoint:s}"')) == sorted(
             [
                 'send to endpoint ""',
                 'send from endpoint ""',
@@ -499,24 +445,16 @@ class TestGrizzlyLanguageServer:
                 ]
             )
         assert len(caplog.messages) == 1
-        assert (
-            caplog.messages[-1]
-            == "unhandled type: variable='{test:Unknown}', variable_type='Unknown'"
-        )
+        assert caplog.messages[-1] == "unhandled type: variable='{test:Unknown}', variable_type='Unknown'"
 
         assert show_message_mock.call_count == 1
         args, kwargs = show_message_mock.call_args_list[-1]
         assert len(args) == 1
-        assert (
-            args[0]
-            == "unhandled type: variable='{test:Unknown}', variable_type='Unknown'"
-        )
+        assert args[0] == "unhandled type: variable='{test:Unknown}', variable_type='Unknown'"
         assert len(kwargs) == 1
         assert kwargs.get('msg_type', None) == 1
 
-    def test__compile_inventory(
-        self, lsp_fixture: LspFixture, caplog: LogCaptureFixture
-    ) -> None:
+    def test__compile_inventory(self, lsp_fixture: LspFixture, caplog: LogCaptureFixture) -> None:
         server = lsp_fixture.server
 
         assert server.steps == {}
@@ -556,9 +494,7 @@ class TestGrizzlyLanguageServer:
         assert 'Given' in server.keywords  # - " -
         assert 'When' in server.keywords
 
-    def test__current_line(
-        self, lsp_fixture: LspFixture, mocker: MockerFixture
-    ) -> None:
+    def test__current_line(self, lsp_fixture: LspFixture, mocker: MockerFixture) -> None:
         server = lsp_fixture.server
 
         mocker.patch.object(server.lsp, 'workspace', Workspace('', None))
@@ -574,38 +510,13 @@ class TestGrizzlyLanguageServer:
             ),
         )
 
-        assert (
-            server._current_line(
-                'file://test.feature', Position(line=0, character=0)
-            ).strip()
-            == 'Feature:'
-        )
-        assert (
-            server._current_line(
-                'file://test.feature', Position(line=1, character=543)
-            ).strip()
-            == 'Scenario: test'
-        )
-        assert (
-            server._current_line(
-                'file://test.feature', Position(line=2, character=435)
-            ).strip()
-            == 'Then hello world!'
-        )
-        assert (
-            server._current_line(
-                'file://test.feature', Position(line=3, character=534)
-            ).strip()
-            == 'But foo bar'
-        )
+        assert server._current_line('file://test.feature', Position(line=0, character=0)).strip() == 'Feature:'
+        assert server._current_line('file://test.feature', Position(line=1, character=543)).strip() == 'Scenario: test'
+        assert server._current_line('file://test.feature', Position(line=2, character=435)).strip() == 'Then hello world!'
+        assert server._current_line('file://test.feature', Position(line=3, character=534)).strip() == 'But foo bar'
 
         with pytest.raises(IndexError) as ie:
-            assert (
-                server._current_line(
-                    'file://test.feature', Position(line=10, character=10)
-                ).strip()
-                == 'Then hello world!'
-            )
+            assert server._current_line('file://test.feature', Position(line=10, character=10)).strip() == 'Then hello world!'
         assert str(ie.value) == 'list index out of range'
 
     def test__find_help(self, lsp_fixture: LspFixture, mocker: MockerFixture) -> None:
@@ -618,20 +529,12 @@ class TestGrizzlyLanguageServer:
             '"" bar': 'this is the help for foo bar parameterized',
         }
 
-        assert (
-            server._find_help('Then hello world') == 'this is the help for hello world'
-        )
+        assert server._find_help('Then hello world') == 'this is the help for hello world'
         assert server._find_help('asdfasdf') is None
         assert server._find_help('And hello') == 'this is the help for hello world'
-        assert (
-            server._find_help('And hello "world"')
-            == 'this is the help for hello world parameterized'
-        )
+        assert server._find_help('And hello "world"') == 'this is the help for hello world parameterized'
         assert server._find_help('But foo') == 'this is the help for foo bar'
-        assert (
-            server._find_help('But "foo" bar')
-            == 'this is the help for foo bar parameterized'
-        )
+        assert server._find_help('But "foo" bar') == 'this is the help for foo bar parameterized'
 
     class TestGrizzlyLangageServerFeatures:
         def _initialize(self, client: LanguageServer, root: Path) -> None:
@@ -673,9 +576,7 @@ class TestGrizzlyLanguageServer:
             finally:
                 logger.setLevel(level)
 
-        def _open(
-            self, client: LanguageServer, path: Path, text: Optional[str] = None
-        ) -> None:
+        def _open(self, client: LanguageServer, path: Path, text: Optional[str] = None) -> None:
             if text is None:
                 text = path.read_text()
 
@@ -692,11 +593,7 @@ class TestGrizzlyLanguageServer:
             )
 
         def _completion(
-            self,
-            client: LanguageServer,
-            path: Path,
-            content: str,
-            context: Optional[CompletionContext] = None,
+            self, client: LanguageServer, path: Path, content: str, context: Optional[CompletionContext] = None, position: Optional[Position] = None
         ) -> Optional[CompletionList]:
             self._initialize(client, path)
 
@@ -710,11 +607,14 @@ class TestGrizzlyLanguageServer:
             if character < 0:
                 character = 0
 
+            if position is None:
+                position = Position(line=line, character=character)
+
             params = CompletionParams(
                 text_document=TextDocumentIdentifier(
                     uri=path.as_uri(),
                 ),
-                position=Position(line=line, character=character),
+                position=position,
                 context=context,
                 partial_result_token=None,
                 work_done_token=None,
@@ -801,9 +701,7 @@ class TestGrizzlyLanguageServer:
 
             assert 'Feature' not in server.keywords  # already used once in feature file
             assert 'Background' not in server.keywords  # - " -
-            assert (
-                'And' in server.keywords
-            )  # just an alias for Given, but we need want it
+            assert 'And' in server.keywords  # just an alias for Given, but we need want it
             assert 'Scenario' in server.keywords  # can be used multiple times
             assert 'Given' in server.keywords  # - " -
             assert 'When' in server.keywords
@@ -814,14 +712,7 @@ class TestGrizzlyLanguageServer:
             def filter_keyword_properties(
                 items: List[CompletionItem],
             ) -> List[Dict[str, Any]]:
-                return [
-                    {
-                        key: getattr(item, key)
-                        for key in item.__dir__()
-                        if key in ['label', 'kind']
-                    }
-                    for item in items
-                ]
+                return [{key: getattr(item, key) for key in item.__dir__() if key in ['label', 'kind']} for item in items]
 
             # partial match, keyword containing 'B'
             response = self._completion(
@@ -878,9 +769,7 @@ class TestGrizzlyLanguageServer:
             response = self._completion(client, lsp_fixture.datadir, '')
             assert response is not None
             assert not response.is_incomplete
-            unexpected_kinds = list(
-                filter(lambda k: k != 14, map(lambda k: k.kind, response.items))
-            )
+            unexpected_kinds = list(filter(lambda k: k != 14, map(lambda k: k.kind, response.items)))
             assert len(unexpected_kinds) == 0
             labels = list(map(lambda k: k.label, response.items))
             assert all([True if label is not None else False for label in labels])
@@ -953,12 +842,91 @@ class TestGrizzlyLanguageServer:
             assert 'a user of type "" with weight "" load testing ""' in labels
             assert 'a user of type "" load testing ""' in labels
 
+            response = self._completion(client, lsp_fixture.datadir, 'Then parse date "{{ datetime.now() }}"')
+            assert response is not None
+            assert not response.is_incomplete
+
+            labels = list(
+                map(lambda s: s.label, response.items),
+            )
+            insert_texts = list(
+                map(lambda s: s.insert_text, response.items),
+            )
+
+            assert labels == ['parse date "{{ datetime.now() }}" and save in variable ""']
+            assert insert_texts == [' and save in variable "$1"']
+
+        def test_completion_variable_names(self, lsp_fixture: LspFixture) -> None:
+            client = lsp_fixture.client
+
+            content = '''Feature: test
+    Scenario: test
+        Given a user of type "Dummy" load testing "dummy://test"
+        And value for variable "price" is "200"
+        And value for variable "foo" is "bar"
+        And value for variable "test" is "False"
+        And ask for value of variable "bar"
+
+        Then parse date "{{'''
+            response = self._completion(client, lsp_fixture.datadir, content)
+
+            assert response is not None
+
+            labels = list(
+                map(lambda s: s.label, response.items),
+            )
+            insert_texts = list([s.insert_text for s in response.items if s.insert_text is not None])
+
+            assert sorted(insert_texts) == sorted(['price }}"', 'foo }}"', 'test }}"', 'bar }}"'])
+            assert sorted(labels) == sorted(['price', 'foo', 'test', 'bar'])
+
+            content = '''Feature: test
+    Scenario: test1
+        Given a user of type "Dummy" load testing "dummy://test"
+        And value for variable "price" is "200"
+        And value for variable "foo" is "bar"
+        And value for variable "test" is "False"
+        And ask for value of variable "bar"
+
+        Then log message "{{
+
+    Scenario: test2
+        Given a user of type "Dummy" load testing "dummy://test"
+        And value for variable "weight" is "200"
+        And value for variable "hello" is "bar"
+        And value for variable "test" is "False"
+        And ask for value of variable "world"
+
+        Then log message "{{"'''
+
+            response = self._completion(client, lsp_fixture.datadir, content, position=Position(line=8, character=27))
+
+            assert response is not None
+
+            labels = list(
+                map(lambda s: s.label, response.items),
+            )
+            insert_texts = list([s.insert_text for s in response.items if s.insert_text is not None])
+
+            assert sorted(insert_texts) == sorted(['price }}"', 'foo }}"', 'test }}"', 'bar }}"'])
+            assert sorted(labels) == sorted(['price', 'foo', 'test', 'bar'])
+
+            response = self._completion(client, lsp_fixture.datadir, content, position=Position(line=17, character=27))
+
+            assert response is not None
+
+            labels = list(
+                map(lambda s: s.label, response.items),
+            )
+            insert_texts = list([s.insert_text for s in response.items if s.insert_text is not None])
+
+            assert sorted(insert_texts) == sorted([' weight }}"', ' hello }}"', ' test }}', ' world }}'])
+            assert sorted(labels) == sorted(['weight', 'hello', 'test', 'world'])
+
         def test_hover(self, lsp_fixture: LspFixture) -> None:
             client = lsp_fixture.client
 
-            response = self._hover(
-                client, lsp_fixture.datadir, Position(line=2, character=31)
-            )
+            response = self._hover(client, lsp_fixture.datadir, Position(line=2, character=31))
 
             assert response is not None
             assert response.range is not None
@@ -991,9 +959,7 @@ Args:
 '''
             )
 
-            response = self._hover(
-                client, lsp_fixture.datadir, Position(line=0, character=1)
-            )
+            response = self._hover(client, lsp_fixture.datadir, Position(line=0, character=1))
 
             assert response is None
 
@@ -1017,9 +983,7 @@ Args:
         def test_definition(self, lsp_fixture: LspFixture) -> None:
             client = lsp_fixture.client
 
-            response = self._definition(
-                client, lsp_fixture.datadir, Position(line=2, character=30)
-            )
+            response = self._definition(client, lsp_fixture.datadir, Position(line=2, character=30))
 
             assert response is None
 


### PR DESCRIPTION
new feature to complete defined variable names. triggered by the position before cursor is `{{`.

fixed bug where partial complete step expression would complete incorrectly.