### PR TITLE
complete partial variable names

### DIFF
--- a/client/vscode/tests/completion.test.ts
+++ b/client/vscode/tests/completion.test.ts
@@ -358,6 +358,29 @@ describe('Should do completion on variables', () => {
         });
     });
 
+    it('Complete variable, partial variable, not a complete step, no ending "', async () => {
+        setTestContent(`Feature:
+    Background:
+    Scenario:
+        And value for variable "foo" is "none"
+        And value for variable "bar" is "none"
+        And value for variable "boo" is "none"
+        And ask for value for variable "world"
+        Then log message "{{ b
+        `);
+
+        const actual = await testCompletion(docUri, new vscode.Position(7, 30));
+        const expected = [
+            'bar }}"',
+            'boo }}"',
+        ];
+
+        actual.items.forEach((item) => {
+            expect(item.kind).to.be.equal(vscode.CompletionItemKind.Variable);
+            expect(expected).to.contain(item.insertText);
+        });
+    });
+
     it('Complete variable, complete step, ending }}"', async () => {
         setTestContent(`Feature:
     Background:
@@ -373,6 +396,28 @@ describe('Should do completion on variables', () => {
             ' foo ',
             ' bar ',
             ' world ',
+        ];
+
+        actual.items.forEach((item) => {
+            expect(item.kind).to.be.equal(vscode.CompletionItemKind.Variable);
+            expect(expected).to.contain(item.insertText);
+        });
+    });
+
+    it('Complete variable, partial variable, complete step, ending }}"', async () => {
+        setTestContent(`Feature:
+    Background:
+    Scenario:
+        And value for variable "foo" is "none"
+        And value for variable "bar" is "none"
+        And ask for value for variable "boo"
+        Then log message "{{ b}}"
+        `);
+
+        const actual = await testCompletion(docUri, new vscode.Position(6, 30));
+        const expected = [
+            'bar ',
+            'boo ',
         ];
 
         actual.items.forEach((item) => {

--- a/client/vscode/tests/completion.test.ts
+++ b/client/vscode/tests/completion.test.ts
@@ -8,6 +8,7 @@ const docUri = getDocUri('features/empty.feature');
 describe('Should do completion on keywords', () => {
     it('Complete keywords, empty file, only suggest first-level keyword(s)', async () => {
         // empty document, only suggest "Feature"
+        setTestContent('');
         const actual = await testCompletion(docUri, new vscode.Position(0, 0));
 
         expect(actual.items.length).to.be.equal(1);

--- a/grizzly-ls/tests/fixtures.py
+++ b/grizzly-ls/tests/fixtures.py
@@ -2,7 +2,7 @@ import os
 import asyncio
 
 from types import TracebackType
-from typing import Literal, Optional, Type
+from typing import Literal, Optional, Type, Any
 from threading import Thread
 from pathlib import Path
 from importlib import reload as reload_module
@@ -12,6 +12,15 @@ from pytest_mock import MockerFixture
 from pygls.server import LanguageServer
 from lsprotocol.types import EXIT
 from grizzly_ls.server import GrizzlyLanguageServer
+
+
+class DummyClient(LanguageServer):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)  # type: ignore
+
+        @self.feature('window/workDoneProgress/create')
+        def window_work_done_progress_create(*args: Any, **kwargs: Any) -> None:
+            return
 
 
 class LspFixture:
@@ -53,7 +62,7 @@ class LspFixture:
         )
         self._server_thread.start()
 
-        self.client = LanguageServer(
+        self.client = DummyClient(
             loop=asyncio.new_event_loop(), name='dummy client', version='0.0.0'
         )
         self._client_thread = Thread(

--- a/grizzly-ls/tests/test_server.py
+++ b/grizzly-ls/tests/test_server.py
@@ -1138,11 +1138,15 @@ class TestGrizzlyLanguageServer:
             labels = list(
                 map(lambda s: s.label, response.items),
             )
-            insert_texts = list(
-                [s.insert_text for s in response.items if s.insert_text is not None]
+            text_edits = list(
+                [
+                    s.text_edit.new_text
+                    for s in response.items
+                    if s.text_edit is not None
+                ]
             )
 
-            assert sorted(insert_texts) == sorted(
+            assert sorted(text_edits) == sorted(
                 [' price }}"', ' foo }}"', ' test }}"', ' bar }}"']
             )
             assert sorted(labels) == sorted(['price', 'foo', 'test', 'bar'])
@@ -1190,11 +1194,15 @@ class TestGrizzlyLanguageServer:
             labels = list(
                 map(lambda s: s.label, response.items),
             )
-            insert_texts = list(
-                [s.insert_text for s in response.items if s.insert_text is not None]
+            text_edits = list(
+                [
+                    s.text_edit.new_text
+                    for s in response.items
+                    if s.text_edit is not None
+                ]
             )
 
-            assert sorted(insert_texts) == sorted(
+            assert sorted(text_edits) == sorted(
                 [' price }}"', ' foo }}"', ' test }}"', ' bar }}"']
             )
             assert sorted(labels) == sorted(['price', 'foo', 'test', 'bar'])
@@ -1213,11 +1221,15 @@ class TestGrizzlyLanguageServer:
             labels = list(
                 map(lambda s: s.label, response.items),
             )
-            insert_texts = list(
-                [s.insert_text for s in response.items if s.insert_text is not None]
+            text_edits = list(
+                [
+                    s.text_edit.new_text
+                    for s in response.items
+                    if s.text_edit is not None
+                ]
             )
 
-            assert sorted(insert_texts) == sorted(
+            assert sorted(text_edits) == sorted(
                 [' weight1 }}', ' hello1 }}', ' test1 }}', ' world1 }}']
             )
             assert sorted(labels) == sorted(['weight1', 'hello1', 'test1', 'world1'])
@@ -1235,11 +1247,15 @@ class TestGrizzlyLanguageServer:
             labels = list(
                 map(lambda s: s.label, response.items),
             )
-            insert_texts = list(
-                [s.insert_text for s in response.items if s.insert_text is not None]
+            text_edits = list(
+                [
+                    s.text_edit.new_text
+                    for s in response.items
+                    if s.text_edit is not None
+                ]
             )
 
-            assert sorted(insert_texts) == sorted(['weight1 }}', 'world1 }}'])
+            assert sorted(text_edits) == sorted(['weight1 }}', 'world1 }}'])
             assert sorted(labels) == sorted(['weight1', 'world1'])
             # // -->
 
@@ -1256,11 +1272,15 @@ class TestGrizzlyLanguageServer:
             labels = list(
                 map(lambda s: s.label, response.items),
             )
-            insert_texts = list(
-                [s.insert_text for s in response.items if s.insert_text is not None]
+            text_edits = list(
+                [
+                    s.text_edit.new_text
+                    for s in response.items
+                    if s.text_edit is not None
+                ]
             )
 
-            assert sorted(insert_texts) == sorted(
+            assert sorted(text_edits) == sorted(
                 [' weight2', ' hello2', ' test2', ' world2']
             )
             assert sorted(labels) == sorted(['weight2', 'hello2', 'test2', 'world2'])
@@ -1278,11 +1298,15 @@ class TestGrizzlyLanguageServer:
             labels = list(
                 map(lambda s: s.label, response.items),
             )
-            insert_texts = list(
-                [s.insert_text for s in response.items if s.insert_text is not None]
+            text_edits = list(
+                [
+                    s.text_edit.new_text
+                    for s in response.items
+                    if s.text_edit is not None
+                ]
             )
 
-            assert sorted(insert_texts) == sorted(['weight2 ', 'world2 '])
+            assert sorted(text_edits) == sorted(['weight2 ', 'world2 '])
             assert sorted(labels) == sorted(['weight2', 'world2'])
             # // -->
 
@@ -1307,11 +1331,15 @@ class TestGrizzlyLanguageServer:
             labels = list(
                 map(lambda s: s.label, response.items),
             )
-            insert_texts = list(
-                [s.insert_text for s in response.items if s.insert_text is not None]
+            text_edits = list(
+                [
+                    s.text_edit.new_text
+                    for s in response.items
+                    if s.text_edit is not None
+                ]
             )
 
-            assert sorted(insert_texts) == sorted(
+            assert sorted(text_edits) == sorted(
                 [' price }}', ' foo }}', ' test }}', ' bar }}']
             )
             assert sorted(labels) == sorted(['price', 'foo', 'test', 'bar'])
@@ -1338,11 +1366,15 @@ class TestGrizzlyLanguageServer:
             labels = list(
                 map(lambda s: s.label, response.items),
             )
-            insert_texts = list(
-                [s.insert_text for s in response.items if s.insert_text is not None]
+            text_edits = list(
+                [
+                    s.text_edit.new_text
+                    for s in response.items
+                    if s.text_edit is not None
+                ]
             )
 
-            assert sorted(insert_texts) == sorted(
+            assert sorted(text_edits) == sorted(
                 [' price }}', ' foo }}', ' test }}', ' bar }}']
             )
             assert sorted(labels) == sorted(['price', 'foo', 'test', 'bar'])
@@ -1360,11 +1392,15 @@ class TestGrizzlyLanguageServer:
             labels = list(
                 map(lambda s: s.label, response.items),
             )
-            insert_texts = list(
-                [s.insert_text for s in response.items if s.insert_text is not None]
+            text_edits = list(
+                [
+                    s.text_edit.new_text
+                    for s in response.items
+                    if s.text_edit is not None
+                ]
             )
 
-            assert sorted(insert_texts) == sorted(
+            assert sorted(text_edits) == sorted(
                 [
                     ' price ',
                     ' foo ',

--- a/grizzly-ls/tests/test_server.py
+++ b/grizzly-ls/tests/test_server.py
@@ -1159,22 +1159,25 @@ class TestGrizzlyLanguageServer:
 
     Scenario: test2
         Given a user of type "Dummy" load testing "dummy://test"
-        And value for variable "weight" is "200"
-        And value for variable "hello" is "bar"
-        And value for variable "test" is "False"
-        And ask for value of variable "world"
+        And value for variable "weight1" is "200"
+        And value for variable "hello1" is "bar"
+        And value for variable "test1" is "False"
+        And ask for value of variable "world1"
 
         Then log message "{{ "
+        Then log message "{{ w"
 
     Scenario: test3
         Given a user of type "Dummy" load testing "dummy://test"
-        And value for variable "weight" is "200"
-        And value for variable "hello" is "bar"
-        And value for variable "test" is "False"
-        And ask for value of variable "world"
+        And value for variable "weight2" is "200"
+        And value for variable "hello2" is "bar"
+        And value for variable "test2" is "False"
+        And ask for value of variable "world2"
 
-        Then log message "{{ }}"'''
+        Then log message "{{ }}"
+        Then log message "{{ w}}"'''
 
+            # <!-- Scenario: test1
             response = self._completion(
                 client,
                 lsp_fixture.datadir,
@@ -1195,7 +1198,9 @@ class TestGrizzlyLanguageServer:
                 [' price }}"', ' foo }}"', ' test }}"', ' bar }}"']
             )
             assert sorted(labels) == sorted(['price', 'foo', 'test', 'bar'])
+            # // -->
 
+            # <!-- Scenario: test2
             response = self._completion(
                 client,
                 lsp_fixture.datadir,
@@ -1213,15 +1218,37 @@ class TestGrizzlyLanguageServer:
             )
 
             assert sorted(insert_texts) == sorted(
-                [' weight }}', ' hello }}', ' test }}', ' world }}']
+                [' weight1 }}', ' hello1 }}', ' test1 }}', ' world1 }}']
             )
-            assert sorted(labels) == sorted(['weight', 'hello', 'test', 'world'])
+            assert sorted(labels) == sorted(['weight1', 'hello1', 'test1', 'world1'])
 
+            # partial variable name
             response = self._completion(
                 client,
                 lsp_fixture.datadir,
                 content,
-                position=Position(line=26, character=28),
+                position=Position(line=18, character=30),
+            )
+
+            assert response is not None
+
+            labels = list(
+                map(lambda s: s.label, response.items),
+            )
+            insert_texts = list(
+                [s.insert_text for s in response.items if s.insert_text is not None]
+            )
+
+            assert sorted(insert_texts) == sorted(['weight1 }}', 'world1 }}'])
+            assert sorted(labels) == sorted(['weight1', 'world1'])
+            # // -->
+
+            # <!-- Scenario: test3
+            response = self._completion(
+                client,
+                lsp_fixture.datadir,
+                content,
+                position=Position(line=27, character=28),
             )
 
             assert response is not None
@@ -1234,9 +1261,30 @@ class TestGrizzlyLanguageServer:
             )
 
             assert sorted(insert_texts) == sorted(
-                [' weight', ' hello', ' test', ' world']
+                [' weight2', ' hello2', ' test2', ' world2']
             )
-            assert sorted(labels) == sorted(['weight', 'hello', 'test', 'world'])
+            assert sorted(labels) == sorted(['weight2', 'hello2', 'test2', 'world2'])
+
+            # partial variable name
+            response = self._completion(
+                client,
+                lsp_fixture.datadir,
+                content,
+                position=Position(line=28, character=30),
+            )
+
+            assert response is not None
+
+            labels = list(
+                map(lambda s: s.label, response.items),
+            )
+            insert_texts = list(
+                [s.insert_text for s in response.items if s.insert_text is not None]
+            )
+
+            assert sorted(insert_texts) == sorted(['weight2 ', 'world2 '])
+            assert sorted(labels) == sorted(['weight2', 'world2'])
+            # // -->
 
             content = '''Feature: test
     Scenario: test


### PR DESCRIPTION
fixes Biometria-se/grizzly#268.

only works if the variable name starts with the partial text. seems like vscode doesn't like any other suggestions, so even if the server sends a suggestion that contains (not starts with) the partial text, it will not show it. 