### PR TITLE
use `text_edit` instead of `insert_text` in `CompletionItem`

### DIFF
--- a/client/vscode/package-lock.json
+++ b/client/vscode/package-lock.json
@@ -32,7 +32,7 @@
         "typescript": "^5.2.2"
       },
       "engines": {
-        "vscode": "^1.63.0"
+        "vscode": "^1.75.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -30,7 +30,7 @@
   ],
   "qna": "false",
   "engines": {
-    "vscode": "^1.75.0"
+    "vscode": "^1.83.x"
   },
   "activationEvents": [],
   "main": "./out/src/extension",

--- a/client/vscode/tests/completion.test.ts
+++ b/client/vscode/tests/completion.test.ts
@@ -17,10 +17,9 @@ describe('Should do completion on keywords', () => {
         // only "Feature" present in document, suggest the two second-level keywords
         const actual = await testCompletion('Feature:\n\t', new vscode.Position(2, 4));
 
-        expect(actual.items.length).to.be.equal(2);
-        expect(actual.items.map((value) => value.label)).to.deep.equal(['Background', 'Scenario']);
+        expect(actual.items.map((value) => value.label)).to.deep.equal(['Background', 'Scenario', 'Scenario Outline', 'Scenario Template']);
         expect(actual.items.map((value) => value.kind)).to.deep.equal(
-            new Array(2).fill(vscode.CompletionItemKind.Keyword)
+            new Array(4).fill(vscode.CompletionItemKind.Keyword)
         );
     });
 
@@ -32,10 +31,9 @@ describe('Should do completion on keywords', () => {
 
         const actual = await testCompletion(content, new vscode.Position(2, 0));
 
-        expect(actual.items.length).to.be.equal(1);
-        expect(actual.items.map((value) => value.label)).to.deep.equal(['Scenario']);
+        expect(actual.items.map((value) => value.label)).to.deep.equal(['Scenario', 'Scenario Outline', 'Scenario Template']);
         expect(actual.items.map((value) => value.kind)).to.deep.equal(
-            new Array(1).fill(vscode.CompletionItemKind.Keyword)
+            new Array(3).fill(vscode.CompletionItemKind.Keyword)
         );
     });
 
@@ -48,18 +46,28 @@ describe('Should do completion on keywords', () => {
 
         const actual = await testCompletion(content, new vscode.Position(3, 0));
 
-        expect(actual.items.length).to.be.equal(6);
         expect(actual.items.map((value) => value.label)).to.deep.equal([
             'And',
             'But',
+            'Examples',
             'Given',
             'Scenario',
+            'Scenario Outline',
+            'Scenario Template',
+            'Scenarios',
             'Then',
             'When',
         ]);
         expect(actual.items.map((value) => value.kind)).to.deep.equal(
-            new Array(6).fill(vscode.CompletionItemKind.Keyword)
+            new Array(10).fill(vscode.CompletionItemKind.Keyword)
         );
+        expect(actual.items.map((value) => {
+            if (value.insertText instanceof vscode.SnippetString) {
+                return value.insertText.value;
+            } else {
+                return value.insertText;
+            }
+        })).to.deep.equal(['And ', 'But ', 'Examples: ', 'Given ', 'Scenario: ', 'Scenario Outline: ', 'Scenario Template: ', 'Scenarios: ', 'Then ', 'When ']);
     });
 
     it('Complete keywords, keywords containing `en` (fuzzy matching)', async () => {
@@ -71,10 +79,9 @@ describe('Should do completion on keywords', () => {
 
         const actual = await testCompletion(content, new vscode.Position(3, 3));
 
-        expect(actual.items.length).to.be.equal(4);
-        expect(actual.items.map((value) => value.label)).to.deep.equal(['Given', 'Scenario', 'Then', 'When']);
+        expect(actual.items.map((value) => value.label)).to.deep.equal(['Given', 'Scenario', 'Scenario Outline', 'Scenario Template', 'Scenarios', 'Then', 'When']);
         expect(actual.items.map((value) => value.kind)).to.deep.equal(
-            new Array(4).fill(vscode.CompletionItemKind.Keyword)
+            new Array(7).fill(vscode.CompletionItemKind.Keyword)
         );
     });
 });

--- a/client/vscode/tests/helper.ts
+++ b/client/vscode/tests/helper.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 
-export let doc: vscode.TextDocument;
-export let editor: vscode.TextEditor;
+export let doc: vscode.TextDocument | undefined = undefined;
+export let editor: vscode.TextEditor | undefined = undefined;
 export let documentEol: string;
 export let platformEol: string;
 
@@ -11,13 +11,15 @@ export const testWorkspace: string = path.resolve(__dirname, '../../../../tests/
 /**
  * Activates the biometria-se.vscode-grizzly extension
  */
-export async function activate(docUri: vscode.Uri) {
+export async function activate(docUri: vscode.Uri, content: string) {
     // The extensionId is `publisher.name` from package.json
     const ext = vscode.extensions.getExtension('biometria-se.grizzly-loadtester-vscode');
     await ext.activate();
     try {
         doc = await vscode.workspace.openTextDocument(docUri);
         editor = await vscode.window.showTextDocument(doc);
+
+        await setTestContent(content);
 
         // wait until language server is done with everything
         while (!ext.exports.isActivated()) {
@@ -39,7 +41,7 @@ export const getDocUri = (p: string) => {
     return vscode.Uri.file(getDocPath(p));
 };
 
-export async function setTestContent(content: string): Promise<boolean> {
+async function setTestContent(content: string): Promise<boolean> {
     const all = new vscode.Range(doc.positionAt(0), doc.positionAt(doc.getText().length));
     return editor.edit((eb) => eb.replace(all, content));
 }

--- a/client/vscode/tests/hover.test.ts
+++ b/client/vscode/tests/hover.test.ts
@@ -1,29 +1,27 @@
 import * as vscode from 'vscode';
 import { expect } from 'chai';
-import { getDocUri, activate, setTestContent } from './helper';
+import { getDocUri, activate } from './helper';
 import { describe, it } from 'mocha';
-
-const docUri = getDocUri('features/empty.feature');
 
 describe('Should show help on hover step expression', () => {
     it('Hover in empty file', async () => {
-        const actual = await testHover(docUri, new vscode.Position(0, 0));
+        const actual = await testHover('', new vscode.Position(0, 0));
         expect(actual).to.be.undefined;
     });
 
     it('Hover `Given a user...`', async () => {
-        setTestContent(`Feature:
+        const content = `Feature:
     Scenario: test scenario
         Given a user of type "RestApi" with weight "1" load testing "$conf::template.host"
         And restart scenario on failure
-`);
+`;
 
         let end = 89;
         if (process.platform == 'win32') {
             end = 90;  // due to \r\n on win32?
         }
 
-        const actual = await testHover(docUri, new vscode.Position(2, 35));
+        const actual = await testHover(content, new vscode.Position(2, 35));
 
         expect(actual.range?.start.line).to.be.equal(2);
         expect(actual.range?.start.character).to.be.equal(8);
@@ -52,18 +50,18 @@ Args:
     });
 
     it('Hover `And restart scenario on failure`', async () => {
-        setTestContent(`Feature:
+        const content = `Feature:
     Scenario: test scenario
         Given a user of type "RestApi" with weight "1" load testing "$conf::template.host"
         And restart scenario on failure
-`);
+`;
 
         let end = 38;
         if (process.platform == 'win32') {
             end = 39;  // due to \r\n on win32?
         }
 
-        const actual = await testHover(docUri, new vscode.Position(3, 13));
+        const actual = await testHover(content, new vscode.Position(3, 13));
 
         expect(actual.range?.start.line).to.be.equal(3);
         expect(actual.range?.start.character).to.be.equal(8);
@@ -86,8 +84,9 @@ And restart scenario on failure
 
 });
 
-async function testHover(docUri: vscode.Uri, position: vscode.Position): Promise<vscode.Hover> {
-    await activate(docUri);
+async function testHover(content: string, position: vscode.Position): Promise<vscode.Hover> {
+    const docUri = getDocUri('features/empty.feature');
+    await activate(docUri, content);
 
     const [hover] = (await vscode.commands.executeCommand(
         'vscode.executeHoverProvider',

--- a/grizzly-ls/pyproject.toml
+++ b/grizzly-ls/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = 'setuptools.build_meta'
 name = 'grizzly-loadtester-ls'
 description = 'LSP server implementation for grizzly-loadtester load scenario development'
 dependencies = [
-    'pygls >=1.0.0,<1.1.0',
+    'pygls >=1.1.0,<1.2.0',
     'behave ==1.2.6'
 ]
 readme = 'README.md'

--- a/grizzly-ls/tests/helpers.py
+++ b/grizzly-ls/tests/helpers.py
@@ -15,3 +15,16 @@ def normalize_completion_item(
         labels.append(value)
 
     return labels
+
+
+def normalize_completion_text_edit(
+    steps: List[CompletionItem],
+    kind: CompletionItemKind,
+) -> List[str]:
+    labels: List[str] = []
+    for step in steps:
+        assert step.kind == kind
+        assert step.text_edit is not None
+        labels.append(step.text_edit.new_text)
+
+    return labels

--- a/grizzly-ls/tests/test_server.py
+++ b/grizzly-ls/tests/test_server.py
@@ -90,21 +90,70 @@ def test_progress(lsp_fixture: LspFixture, mocker: MockerFixture) -> None:
 
 
 class TestGrizzlyLanguageServer:
-    def test___init__(self, lsp_fixture: LspFixture) -> None:
+    @pytest.mark.parametrize(
+        'language,words',
+        [
+            (
+                'en',
+                {
+                    'keywords': [
+                        'Scenario',
+                        'Scenario Outline',
+                        'Scenario Template',
+                        'Examples',
+                        'Scenarios',
+                        'And',
+                        'But',
+                    ],
+                    'keywords_any': ['*', 'But', 'And'],
+                    'keywords_once': ['Feature', 'Background'],
+                },
+            ),
+            (
+                'sv',
+                {
+                    'keywords': [
+                        'Scenario',
+                        'Abstrakt Scenario',
+                        'Scenariomall',
+                        'Exempel',
+                        'Och',
+                        'Men',
+                    ],
+                    'keywords_any': ['*', 'Men', 'Och'],
+                    'keywords_once': ['Egenskap', 'Bakgrund'],
+                },
+            ),
+            (
+                'de',
+                {
+                    'keywords': [
+                        'Szenario',
+                        'Szenariogrundriss',
+                        'Beispiele',
+                        'Und',
+                        'Aber',
+                    ],
+                    'keywords_any': ['*', 'Und', 'Aber'],
+                    'keywords_once': ['Grundlage', u'Funktionalit\xe4t'],
+                },
+            ),
+        ],
+    )
+    def test___init__(
+        self, language: str, words: Dict[str, List[str]], lsp_fixture: LspFixture
+    ) -> None:
         server = lsp_fixture.server
+        server.language = language
 
         assert server.name == 'grizzly-ls'
         assert server.version == __version__
         assert server.steps == {}
-        assert sorted(server.keywords) == sorted(['Scenario', 'And', 'But'])
-        assert sorted(server.keywords_any) == sorted(
-            [
-                '*',
-                'But',
-                'And',
-            ]
+        assert sorted(server.keywords) == sorted(
+            words.get('keywords', []),
         )
-        assert sorted(server.keywords_once) == sorted(['Feature', 'Background'])
+        assert sorted(server.keywords_any) == sorted(words.get('keywords_any', []))
+        assert sorted(server.keywords_once) == sorted(words.get('keywords_once', []))
 
         assert isinstance(server.logger, logging.Logger)
         assert server.logger.name == 'grizzly_ls.server'
@@ -192,8 +241,11 @@ class TestGrizzlyLanguageServer:
             source='',
         )
 
+        null_position = Position(line=0, character=0)
+
         assert normalize_completion_item(
-            server._complete_keyword(None, document), CompletionItemKind.Keyword
+            server._complete_keyword(None, null_position, document),
+            CompletionItemKind.Keyword,
         ) == [
             'Feature',
         ]
@@ -203,12 +255,19 @@ class TestGrizzlyLanguageServer:
             source='Feature:',
         )
 
-        assert normalize_completion_item(
-            server._complete_keyword(None, document), CompletionItemKind.Keyword
-        ) == [
-            'Background',
-            'Scenario',
-        ]
+        assert sorted(
+            normalize_completion_item(
+                server._complete_keyword(None, null_position, document),
+                CompletionItemKind.Keyword,
+            )
+        ) == sorted(
+            [
+                'Background',
+                'Scenario',
+                'Scenario Outline',
+                'Scenario Template',
+            ]
+        )
 
         document = Document(
             uri='dummy.feature',
@@ -217,17 +276,26 @@ class TestGrizzlyLanguageServer:
 ''',
         )
 
-        assert normalize_completion_item(
-            server._complete_keyword(None, document), CompletionItemKind.Keyword
-        ) == [
-            'And',
-            'Background',
-            'But',
-            'Given',
-            'Scenario',
-            'Then',
-            'When',
-        ]
+        assert sorted(
+            normalize_completion_item(
+                server._complete_keyword(None, null_position, document),
+                CompletionItemKind.Keyword,
+            )
+        ) == sorted(
+            [
+                'And',
+                'Background',
+                'But',
+                'Given',
+                'Scenario',
+                'Scenario Outline',
+                'Scenario Template',
+                'Then',
+                'When',
+                'Examples',
+                'Scenarios',
+            ]
+        )
 
         document = Document(
             uri='dummy.feature',
@@ -238,28 +306,46 @@ class TestGrizzlyLanguageServer:
 ''',
         )
 
-        assert normalize_completion_item(
-            server._complete_keyword(None, document), CompletionItemKind.Keyword
-        ) == [
-            'And',
-            'But',
-            'Given',
-            'Scenario',
-            'Then',
-            'When',
-        ]
+        assert sorted(
+            normalize_completion_item(
+                server._complete_keyword(None, null_position, document),
+                CompletionItemKind.Keyword,
+            )
+        ) == sorted(
+            [
+                'And',
+                'But',
+                'Given',
+                'Scenario',
+                'Scenario Outline',
+                'Scenario Template',
+                'Examples',
+                'Scenarios',
+                'Then',
+                'When',
+            ]
+        )
+
+        assert sorted(
+            normalize_completion_item(
+                server._complete_keyword('EN', Position(line=0, character=2), document),
+                CompletionItemKind.Keyword,
+            )
+        ) == sorted(
+            [
+                'Given',
+                'Scenario',
+                'Scenario Template',
+                'Scenario Outline',
+                'Scenarios',
+                'Then',
+                'When',
+            ]
+        )
 
         assert normalize_completion_item(
-            server._complete_keyword('EN', document), CompletionItemKind.Keyword
-        ) == [
-            'Given',
-            'Scenario',
-            'Then',
-            'When',
-        ]
-
-        assert normalize_completion_item(
-            server._complete_keyword('Giv', document), CompletionItemKind.Keyword
+            server._complete_keyword('Giv', Position(line=0, character=4), document),
+            CompletionItemKind.Keyword,
         ) == [
             'Given',
         ]
@@ -988,9 +1074,11 @@ class TestGrizzlyLanguageServer:
             ) -> List[Dict[str, Any]]:
                 return [
                     {
-                        key: getattr(item, key)
-                        for key in item.__dir__()
-                        if key in ['label', 'kind']
+                        'label': item.label,
+                        'kind': item.kind,
+                        'text_edit': item.text_edit.new_text
+                        if item.text_edit is not None
+                        else None,
                     }
                     for item in items
                 ]
@@ -1008,13 +1096,11 @@ class TestGrizzlyLanguageServer:
             assert response is not None
             assert not response.is_incomplete
             assert filter_keyword_properties(response.items) == [
-                {
-                    'label': 'Background',
-                    'kind': 14,
-                },
+                {'label': 'Background', 'kind': 14, 'text_edit': 'Background: '},
                 {
                     'label': 'But',
                     'kind': 14,
+                    'text_edit': 'But ',
                 },
             ]
 
@@ -1033,18 +1119,37 @@ class TestGrizzlyLanguageServer:
                 {
                     'label': 'Given',
                     'kind': 14,
+                    'text_edit': 'Given ',
                 },
                 {
                     'label': 'Scenario',
                     'kind': 14,
+                    'text_edit': 'Scenario: ',
+                },
+                {
+                    'label': 'Scenario Outline',
+                    'kind': 14,
+                    'text_edit': 'Scenario Outline: ',
+                },
+                {
+                    'label': 'Scenario Template',
+                    'kind': 14,
+                    'text_edit': 'Scenario Template: ',
+                },
+                {
+                    'label': 'Scenarios',
+                    'kind': 14,
+                    'text_edit': 'Scenarios: ',
                 },
                 {
                     'label': 'Then',
                     'kind': 14,
+                    'text_edit': 'Then ',
                 },
                 {
                     'label': 'When',
                     'kind': 14,
+                    'text_edit': 'When ',
                 },
             ]
 
@@ -1052,13 +1157,15 @@ class TestGrizzlyLanguageServer:
             response = self._completion(client, lsp_fixture.datadir, '', options=None)
             assert response is not None
             assert not response.is_incomplete
-            unexpected_kinds = list(
-                filter(lambda k: k != 14, map(lambda k: k.kind, response.items))
-            )
+            unexpected_kinds = [k.kind for k in response.items if k.kind != 14]
             assert len(unexpected_kinds) == 0
-            labels = list(map(lambda k: k.label, response.items))
+            labels = [k.label for k in response.items]
+            text_edits = [
+                k.text_edit.new_text for k in response.items if k.text_edit is not None
+            ]
             assert all([True if label is not None else False for label in labels])
             assert labels == ['Feature']
+            assert text_edits == ['Feature: ']
 
         def test_completion_steps(self, lsp_fixture: LspFixture) -> None:
             client = lsp_fixture.client


### PR DESCRIPTION
makes inserting/replacing text more predictable and not client (vscode) dependant.

cleaned up `clients/vscode` unit tests.

improved keyword completion logic.

upgraded `pygls` to 1.1.1.

closes Biometria-se/grizzly#271.