### PR TITLE
completion improvements

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 RUN curl https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash
 
 # [Optional] Uncomment this line to install global node packages.
-RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g xvfb-maybe vsce" 2>&1
+RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g xvfb-maybe @vscode/vsce" 2>&1
 
 RUN rm -rf /etc/localtime || true
 

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -81,15 +81,12 @@ jobs:
           bash ./script/install.sh server +e
           npm install -g @vscode/vsce
 
-          python -c 'import sys; print(sys.executable)'
-          python --version
-          echo "VIRTUAL_ENV=$pythonLocation" >> $GITHUB_ENV
-
       - name: test
         id: test
         uses: hankolsen/xvfb-action@dcb076c1c3802845f73bb6fe14a009d8d3377255
         env:
           VERBOSE: true
+          VIRTUAL_ENV: ${{env.pythonLocation}}
         with:
           run: |
             npm test

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -81,6 +81,10 @@ jobs:
           bash ./script/install.sh server +e
           npm install -g @vscode/vsce
 
+          python -c 'import sys; print(sys.executable)'
+          python --version
+          echo "VIRTUAL_ENV=$pythonLocation" >> $GITHUB_ENV
+
       - name: test
         id: test
         uses: hankolsen/xvfb-action@dcb076c1c3802845f73bb6fe14a009d8d3377255

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -79,7 +79,7 @@ jobs:
         run: |
           bash ./script/install.sh client/vscode
           bash ./script/install.sh server +e
-          npm install -g vsce
+          npm install -g @vscode/vsce
 
       - name: test
         id: test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -139,7 +139,7 @@ jobs:
       - name: install dependencies
         run: |
           npm install
-          npm install -g vsce
+          npm install -g @vscode/vsce
 
       - name: build
         run: |

--- a/client/vscode/package-lock.json
+++ b/client/vscode/package-lock.json
@@ -13,28 +13,28 @@
         "vscode-languageclient": "^9.0.1"
       },
       "devDependencies": {
-        "@types/chai": "^4.3.11",
-        "@types/glob": "^8.1.0",
-        "@types/mocha": "^10.0.6",
-        "@types/node": "^20.10.5",
-        "@types/vscode": "^1.85.0",
-        "@typescript-eslint/eslint-plugin": "^6.15.0",
-        "@typescript-eslint/parser": "^6.15.0",
-        "@vscode/test-electron": "^2.3.8",
+        "@types/chai": "^4.3.6",
+        "@types/glob": "^8.0.0",
+        "@types/mocha": "^10.0.2",
+        "@types/node": "^20.8.2",
+        "@types/vscode": "^1.63.0",
+        "@typescript-eslint/eslint-plugin": "^6.7.4",
+        "@typescript-eslint/parser": "^6.7.4",
+        "@vscode/test-electron": "^2.3.5",
         "chai": "^4.3.10",
-        "esbuild": "^0.19.10",
-        "eslint": "^8.56.0",
-        "eslint-config-standard-with-typescript": "^43.0.0",
-        "eslint-plugin-import": "^2.29.1",
-        "eslint-plugin-n": "^16.5.0",
-        "eslint-plugin-promise": "^6.1.1",
+        "esbuild": "^0.19.4",
+        "eslint": "^8.22.0",
+        "eslint-config-standard-with-typescript": "^39.1.0",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-n": "^16.1.0",
+        "eslint-plugin-promise": "^6.0.0",
         "mocha": "^10.2.0",
         "npm-license-crawler": "^0.2.1",
-        "typescript": "^5.3.3"
+        "typescript": "^5.2.2"
       },
       "engines": {
         "node": ">=16.17.1",
-        "vscode": "^1.85.0"
+        "vscode": "^1.83.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1710,9 +1710,9 @@
       }
     },
     "node_modules/eslint-config-standard-with-typescript": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-43.0.0.tgz",
-      "integrity": "sha512-AT0qK01M5bmsWiE3UZvaQO5da1y1n6uQckAKqGNe6zPW5IOzgMLXZxw77nnFm+C11nxAZXsCPrbsgJhSrGfX6Q==",
+      "version": "39.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-39.1.1.tgz",
+      "integrity": "sha512-t6B5Ep8E4I18uuoYeYxINyqcXb2UbC0SOOTxRtBSt2JUs+EzeXbfe2oaiPs71AIdnoWhXDO2fYOHz8df3kV84A==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/parser": "^6.4.0",

--- a/client/vscode/package-lock.json
+++ b/client/vscode/package-lock.json
@@ -13,28 +13,28 @@
         "vscode-languageclient": "^9.0.1"
       },
       "devDependencies": {
-        "@types/chai": "^4.3.6",
-        "@types/glob": "^8.0.0",
-        "@types/mocha": "^10.0.2",
-        "@types/node": "^20.8.2",
-        "@types/vscode": "^1.63.0",
-        "@typescript-eslint/eslint-plugin": "^6.7.4",
-        "@typescript-eslint/parser": "^6.7.4",
-        "@vscode/test-electron": "^2.3.5",
+        "@types/chai": "^4.3.11",
+        "@types/glob": "^8.1.0",
+        "@types/mocha": "^10.0.6",
+        "@types/node": "^20.10.5",
+        "@types/vscode": "^1.85.0",
+        "@typescript-eslint/eslint-plugin": "^6.15.0",
+        "@typescript-eslint/parser": "^6.15.0",
+        "@vscode/test-electron": "^2.3.8",
         "chai": "^4.3.10",
-        "esbuild": "^0.19.4",
-        "eslint": "^8.22.0",
-        "eslint-config-standard-with-typescript": "^39.1.0",
-        "eslint-plugin-import": "^2.26.0",
-        "eslint-plugin-n": "^16.1.0",
-        "eslint-plugin-promise": "^6.0.0",
+        "esbuild": "^0.19.10",
+        "eslint": "^8.56.0",
+        "eslint-config-standard-with-typescript": "^43.0.0",
+        "eslint-plugin-import": "^2.29.1",
+        "eslint-plugin-n": "^16.5.0",
+        "eslint-plugin-promise": "^6.1.1",
         "mocha": "^10.2.0",
         "npm-license-crawler": "^0.2.1",
-        "typescript": "^5.2.2"
+        "typescript": "^5.3.3"
       },
       "engines": {
         "node": ">=16.17.1",
-        "vscode": "^1.83.0"
+        "vscode": "^1.85.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -46,10 +46,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.10.tgz",
+      "integrity": "sha512-Q+mk96KJ+FZ30h9fsJl+67IjNJm3x2eX+GBWGmocAKgzp27cowCOOqSdscX80s0SpdFXZnIv/+1xD1EctFx96Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.4.tgz",
-      "integrity": "sha512-uBIbiYMeSsy2U0XQoOGVVcpIktjLMEKa7ryz2RLr7L/vTnANNEsPVAh4xOv7ondGz6ac1zVb0F8Jx20rQikffQ==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.10.tgz",
+      "integrity": "sha512-7W0bK7qfkw1fc2viBfrtAEkDKHatYfHzr/jKAHNr9BvkYDXPcC6bodtm8AyLJNNuqClLNaeTLuwURt4PRT9d7w==",
       "cpu": [
         "arm"
       ],
@@ -63,9 +79,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.4.tgz",
-      "integrity": "sha512-mRsi2vJsk4Bx/AFsNBqOH2fqedxn5L/moT58xgg51DjX1la64Z3Npicut2VbhvDFO26qjWtPMsVxCd80YTFVeg==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.10.tgz",
+      "integrity": "sha512-1X4CClKhDgC3by7k8aOWZeBXQX8dHT5QAMCAQDArCLaYfkppoARvh0fit3X2Qs+MXDngKcHv6XXyQCpY0hkK1Q==",
       "cpu": [
         "arm64"
       ],
@@ -79,9 +95,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.4.tgz",
-      "integrity": "sha512-4iPufZ1TMOD3oBlGFqHXBpa3KFT46aLl6Vy7gwed0ZSYgHaZ/mihbYb4t7Z9etjkC9Al3ZYIoOaHrU60gcMy7g==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.10.tgz",
+      "integrity": "sha512-O/nO/g+/7NlitUxETkUv/IvADKuZXyH4BHf/g/7laqKC4i/7whLpB0gvpPc2zpF0q9Q6FXS3TS75QHac9MvVWw==",
       "cpu": [
         "x64"
       ],
@@ -95,9 +111,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.4.tgz",
-      "integrity": "sha512-Lviw8EzxsVQKpbS+rSt6/6zjn9ashUZ7Tbuvc2YENgRl0yZTktGlachZ9KMJUsVjZEGFVu336kl5lBgDN6PmpA==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.10.tgz",
+      "integrity": "sha512-YSRRs2zOpwypck+6GL3wGXx2gNP7DXzetmo5pHXLrY/VIMsS59yKfjPizQ4lLt5vEI80M41gjm2BxrGZ5U+VMA==",
       "cpu": [
         "arm64"
       ],
@@ -111,9 +127,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.4.tgz",
-      "integrity": "sha512-YHbSFlLgDwglFn0lAO3Zsdrife9jcQXQhgRp77YiTDja23FrC2uwnhXMNkAucthsf+Psr7sTwYEryxz6FPAVqw==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.10.tgz",
+      "integrity": "sha512-alfGtT+IEICKtNE54hbvPg13xGBe4GkVxyGWtzr+yHO7HIiRJppPDhOKq3zstTcVf8msXb/t4eavW3jCDpMSmA==",
       "cpu": [
         "x64"
       ],
@@ -127,9 +143,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.4.tgz",
-      "integrity": "sha512-vz59ijyrTG22Hshaj620e5yhs2dU1WJy723ofc+KUgxVCM6zxQESmWdMuVmUzxtGqtj5heHyB44PjV/HKsEmuQ==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.10.tgz",
+      "integrity": "sha512-dMtk1wc7FSH8CCkE854GyGuNKCewlh+7heYP/sclpOG6Cectzk14qdUIY5CrKDbkA/OczXq9WesqnPl09mj5dg==",
       "cpu": [
         "arm64"
       ],
@@ -143,9 +159,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.4.tgz",
-      "integrity": "sha512-3sRbQ6W5kAiVQRBWREGJNd1YE7OgzS0AmOGjDmX/qZZecq8NFlQsQH0IfXjjmD0XtUYqr64e0EKNFjMUlPL3Cw==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.10.tgz",
+      "integrity": "sha512-G5UPPspryHu1T3uX8WiOEUa6q6OlQh6gNl4CO4Iw5PS+Kg5bVggVFehzXBJY6X6RSOMS8iXDv2330VzaObm4Ag==",
       "cpu": [
         "x64"
       ],
@@ -159,9 +175,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.4.tgz",
-      "integrity": "sha512-z/4ArqOo9EImzTi4b6Vq+pthLnepFzJ92BnofU1jgNlcVb+UqynVFdoXMCFreTK7FdhqAzH0vmdwW5373Hm9pg==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.10.tgz",
+      "integrity": "sha512-j6gUW5aAaPgD416Hk9FHxn27On28H4eVI9rJ4az7oCGTFW48+LcgNDBN+9f8rKZz7EEowo889CPKyeaD0iw9Kg==",
       "cpu": [
         "arm"
       ],
@@ -175,9 +191,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.4.tgz",
-      "integrity": "sha512-ZWmWORaPbsPwmyu7eIEATFlaqm0QGt+joRE9sKcnVUG3oBbr/KYdNE2TnkzdQwX6EDRdg/x8Q4EZQTXoClUqqA==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.10.tgz",
+      "integrity": "sha512-QxaouHWZ+2KWEj7cGJmvTIHVALfhpGxo3WLmlYfJ+dA5fJB6lDEIg+oe/0//FuyVHuS3l79/wyBxbHr0NgtxJQ==",
       "cpu": [
         "arm64"
       ],
@@ -191,9 +207,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.4.tgz",
-      "integrity": "sha512-EGc4vYM7i1GRUIMqRZNCTzJh25MHePYsnQfKDexD8uPTCm9mK56NIL04LUfX2aaJ+C9vyEp2fJ7jbqFEYgO9lQ==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.10.tgz",
+      "integrity": "sha512-4ub1YwXxYjj9h1UIZs2hYbnTZBtenPw5NfXCRgEkGb0b6OJ2gpkMvDqRDYIDRjRdWSe/TBiZltm3Y3Q8SN1xNg==",
       "cpu": [
         "ia32"
       ],
@@ -207,9 +223,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.4.tgz",
-      "integrity": "sha512-WVhIKO26kmm8lPmNrUikxSpXcgd6HDog0cx12BUfA2PkmURHSgx9G6vA19lrlQOMw+UjMZ+l3PpbtzffCxFDRg==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.10.tgz",
+      "integrity": "sha512-lo3I9k+mbEKoxtoIbM0yC/MZ1i2wM0cIeOejlVdZ3D86LAcFXFRdeuZmh91QJvUTW51bOK5W2BznGNIl4+mDaA==",
       "cpu": [
         "loong64"
       ],
@@ -223,9 +239,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.4.tgz",
-      "integrity": "sha512-keYY+Hlj5w86hNp5JJPuZNbvW4jql7c1eXdBUHIJGTeN/+0QFutU3GrS+c27L+NTmzi73yhtojHk+lr2+502Mw==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.10.tgz",
+      "integrity": "sha512-J4gH3zhHNbdZN0Bcr1QUGVNkHTdpijgx5VMxeetSk6ntdt+vR1DqGmHxQYHRmNb77tP6GVvD+K0NyO4xjd7y4A==",
       "cpu": [
         "mips64el"
       ],
@@ -239,9 +255,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.4.tgz",
-      "integrity": "sha512-tQ92n0WMXyEsCH4m32S21fND8VxNiVazUbU4IUGVXQpWiaAxOBvtOtbEt3cXIV3GEBydYsY8pyeRMJx9kn3rvw==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.10.tgz",
+      "integrity": "sha512-tgT/7u+QhV6ge8wFMzaklOY7KqiyitgT1AUHMApau32ZlvTB/+efeCtMk4eXS+uEymYK249JsoiklZN64xt6oQ==",
       "cpu": [
         "ppc64"
       ],
@@ -255,9 +271,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.4.tgz",
-      "integrity": "sha512-tRRBey6fG9tqGH6V75xH3lFPpj9E8BH+N+zjSUCnFOX93kEzqS0WdyJHkta/mmJHn7MBaa++9P4ARiU4ykjhig==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.10.tgz",
+      "integrity": "sha512-0f/spw0PfBMZBNqtKe5FLzBDGo0SKZKvMl5PHYQr3+eiSscfJ96XEknCe+JoOayybWUFQbcJTrk946i3j9uYZA==",
       "cpu": [
         "riscv64"
       ],
@@ -271,9 +287,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.4.tgz",
-      "integrity": "sha512-152aLpQqKZYhThiJ+uAM4PcuLCAOxDsCekIbnGzPKVBRUDlgaaAfaUl5NYkB1hgY6WN4sPkejxKlANgVcGl9Qg==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.10.tgz",
+      "integrity": "sha512-pZFe0OeskMHzHa9U38g+z8Yx5FNCLFtUnJtQMpwhS+r4S566aK2ci3t4NCP4tjt6d5j5uo4h7tExZMjeKoehAA==",
       "cpu": [
         "s390x"
       ],
@@ -287,9 +303,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.4.tgz",
-      "integrity": "sha512-Mi4aNA3rz1BNFtB7aGadMD0MavmzuuXNTaYL6/uiYIs08U7YMPETpgNn5oue3ICr+inKwItOwSsJDYkrE9ekVg==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.10.tgz",
+      "integrity": "sha512-SpYNEqg/6pZYoc+1zLCjVOYvxfZVZj6w0KROZ3Fje/QrM3nfvT2llI+wmKSrWuX6wmZeTapbarvuNNK/qepSgA==",
       "cpu": [
         "x64"
       ],
@@ -303,9 +319,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.4.tgz",
-      "integrity": "sha512-9+Wxx1i5N/CYo505CTT7T+ix4lVzEdz0uCoYGxM5JDVlP2YdDC1Bdz+Khv6IbqmisT0Si928eAxbmGkcbiuM/A==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.10.tgz",
+      "integrity": "sha512-ACbZ0vXy9zksNArWlk2c38NdKg25+L9pr/mVaj9SUq6lHZu/35nx2xnQVRGLrC1KKQqJKRIB0q8GspiHI3J80Q==",
       "cpu": [
         "x64"
       ],
@@ -319,9 +335,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.4.tgz",
-      "integrity": "sha512-MFsHleM5/rWRW9EivFssop+OulYVUoVcqkyOkjiynKBCGBj9Lihl7kh9IzrreDyXa4sNkquei5/DTP4uCk25xw==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.10.tgz",
+      "integrity": "sha512-PxcgvjdSjtgPMiPQrM3pwSaG4kGphP+bLSb+cihuP0LYdZv1epbAIecHVl5sD3npkfYBZ0ZnOjR878I7MdJDFg==",
       "cpu": [
         "x64"
       ],
@@ -335,9 +351,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.4.tgz",
-      "integrity": "sha512-6Xq8SpK46yLvrGxjp6HftkDwPP49puU4OF0hEL4dTxqCbfx09LyrbUj/D7tmIRMj5D5FCUPksBbxyQhp8tmHzw==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.10.tgz",
+      "integrity": "sha512-ZkIOtrRL8SEJjr+VHjmW0znkPs+oJXhlJbNwfI37rvgeMtk3sxOQevXPXjmAPZPigVTncvFqLMd+uV0IBSEzqA==",
       "cpu": [
         "x64"
       ],
@@ -351,9 +367,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.4.tgz",
-      "integrity": "sha512-PkIl7Jq4mP6ke7QKwyg4fD4Xvn8PXisagV/+HntWoDEdmerB2LTukRZg728Yd1Fj+LuEX75t/hKXE2Ppk8Hh1w==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.10.tgz",
+      "integrity": "sha512-+Sa4oTDbpBfGpl3Hn3XiUe4f8TU2JF7aX8cOfqFYMMjXp6ma6NJDztl5FDG8Ezx0OjwGikIHw+iA54YLDNNVfw==",
       "cpu": [
         "arm64"
       ],
@@ -367,9 +383,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.4.tgz",
-      "integrity": "sha512-ga676Hnvw7/ycdKB53qPusvsKdwrWzEyJ+AtItHGoARszIqvjffTwaaW3b2L6l90i7MO9i+dlAW415INuRhSGg==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.10.tgz",
+      "integrity": "sha512-EOGVLK1oWMBXgfttJdPHDTiivYSjX6jDNaATeNOaCOFEVcfMjtbx7WVQwPSE1eIfCp/CaSF2nSrDtzc4I9f8TQ==",
       "cpu": [
         "ia32"
       ],
@@ -383,9 +399,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.4.tgz",
-      "integrity": "sha512-HP0GDNla1T3ZL8Ko/SHAS2GgtjOg+VmWnnYLhuTksr++EnduYB0f3Y2LzHsUwb2iQ13JGoY6G3R8h6Du/WG6uA==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.10.tgz",
+      "integrity": "sha512-whqLG6Sc70AbU73fFYvuYzaE4MNMBIlR1Y/IrUeOXFrWHxBEjjbZaQ3IXIQS8wJdAzue2GwYZCjOrgrU1oUHoA==",
       "cpu": [
         "x64"
       ],
@@ -423,9 +439,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
-      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -446,21 +462,21 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.50.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.50.0.tgz",
-      "integrity": "sha512-NCC3zz2+nvYd+Ckfh87rA47zfu2QsQpvc6k1yzTk+b9KzRj0wkGa8LSoGOXN6Zv4lRf/EIoZ80biDh9HOI+RNQ==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
+      "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.11",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
-      "integrity": "sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==",
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
+      "integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
       "dev": true,
       "dependencies": {
-        "@humanwhocodes/object-schema": "^1.2.1",
+        "@humanwhocodes/object-schema": "^2.0.1",
         "debug": "^4.1.1",
         "minimatch": "^3.0.5"
       },
@@ -482,9 +498,9 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
+      "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
       "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -532,9 +548,9 @@
       }
     },
     "node_modules/@types/chai": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.6.tgz",
-      "integrity": "sha512-VOVRLM1mBxIRxydiViqPcKn6MIxZytrbMpd6RJLIWKxUNr3zux8no0Oc7kJx0WAPIitgZ0gkrDS+btlqQpubpw==",
+      "version": "4.3.11",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.11.tgz",
+      "integrity": "sha512-qQR1dr2rGIHYlJulmr8Ioq3De0Le9E4MJ5AiaeAETJJpndT1uUNHsGFK3L/UIu+rbkQSdj8J/w2bCsBZc/Y5fQ==",
       "dev": true
     },
     "node_modules/@types/glob": {
@@ -548,9 +564,9 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.13",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
-      "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==",
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
     "node_modules/@types/json5": {
@@ -566,40 +582,43 @@
       "dev": true
     },
     "node_modules/@types/mocha": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.2.tgz",
-      "integrity": "sha512-NaHL0+0lLNhX6d9rs+NSt97WH/gIlRHmszXbQ/8/MV/eVcFNdeJ/GYhrFuUc8K7WuPhRhTSdMkCp8VMzhUq85w==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
+      "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.8.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.2.tgz",
-      "integrity": "sha512-Vvycsc9FQdwhxE3y3DzeIxuEJbWGDsnrxvMADzTDF/lcdR9/K+AQIeAghTQsHtotg/q0j3WEOYS/jQgSdWue3w==",
-      "dev": true
+      "version": "20.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
+      "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+      "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.82.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
-      "integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
+      "version": "1.85.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.85.0.tgz",
+      "integrity": "sha512-CF/RBon/GXwdfmnjZj0WTUMZN5H6YITOfBCP4iEZlOtVQXuzw6t7Le7+cR+7JzdMrnlm7Mfp49Oj2TuSXIWo3g==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.7.4.tgz",
-      "integrity": "sha512-DAbgDXwtX+pDkAHwiGhqP3zWUGpW49B7eqmgpPtg+BKJXwdct79ut9+ifqOFPJGClGKSHXn2PTBatCnldJRUoA==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.15.0.tgz",
+      "integrity": "sha512-j5qoikQqPccq9QoBAupOP+CBu8BaJ8BLjaXSioDISeTZkVO3ig7oSIKh3H+rEpee7xCXtWwSB4KIL5l6hWZzpg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.7.4",
-        "@typescript-eslint/type-utils": "6.7.4",
-        "@typescript-eslint/utils": "6.7.4",
-        "@typescript-eslint/visitor-keys": "6.7.4",
+        "@typescript-eslint/scope-manager": "6.15.0",
+        "@typescript-eslint/type-utils": "6.15.0",
+        "@typescript-eslint/utils": "6.15.0",
+        "@typescript-eslint/visitor-keys": "6.15.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -625,15 +644,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.4.tgz",
-      "integrity": "sha512-I5zVZFY+cw4IMZUeNCU7Sh2PO5O57F7Lr0uyhgCJmhN/BuTlnc55KxPonR4+EM3GBdfiCyGZye6DgMjtubQkmA==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.15.0.tgz",
+      "integrity": "sha512-MkgKNnsjC6QwcMdlNAel24jjkEO/0hQaMDLqP4S9zq5HBAUJNQB6y+3DwLjX7b3l2b37eNAxMPLwb3/kh8VKdA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.7.4",
-        "@typescript-eslint/types": "6.7.4",
-        "@typescript-eslint/typescript-estree": "6.7.4",
-        "@typescript-eslint/visitor-keys": "6.7.4",
+        "@typescript-eslint/scope-manager": "6.15.0",
+        "@typescript-eslint/types": "6.15.0",
+        "@typescript-eslint/typescript-estree": "6.15.0",
+        "@typescript-eslint/visitor-keys": "6.15.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -653,13 +672,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.4.tgz",
-      "integrity": "sha512-SdGqSLUPTXAXi7c3Ob7peAGVnmMoGzZ361VswK2Mqf8UOYcODiYvs8rs5ILqEdfvX1lE7wEZbLyELCW+Yrql1A==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.15.0.tgz",
+      "integrity": "sha512-+BdvxYBltqrmgCNu4Li+fGDIkW9n//NrruzG9X1vBzaNK+ExVXPoGB71kneaVw/Jp+4rH/vaMAGC6JfMbHstVg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.7.4",
-        "@typescript-eslint/visitor-keys": "6.7.4"
+        "@typescript-eslint/types": "6.15.0",
+        "@typescript-eslint/visitor-keys": "6.15.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -670,13 +689,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.7.4.tgz",
-      "integrity": "sha512-n+g3zi1QzpcAdHFP9KQF+rEFxMb2KxtnJGID3teA/nxKHOVi3ylKovaqEzGBbVY2pBttU6z85gp0D00ufLzViQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.15.0.tgz",
+      "integrity": "sha512-CnmHKTfX6450Bo49hPg2OkIm/D/TVYV7jO1MCfPYGwf6x3GO0VU8YMO5AYMn+u3X05lRRxA4fWCz87GFQV6yVQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.7.4",
-        "@typescript-eslint/utils": "6.7.4",
+        "@typescript-eslint/typescript-estree": "6.15.0",
+        "@typescript-eslint/utils": "6.15.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -697,9 +716,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.4.tgz",
-      "integrity": "sha512-o9XWK2FLW6eSS/0r/tgjAGsYasLAnOWg7hvZ/dGYSSNjCh+49k5ocPN8OmG5aZcSJ8pclSOyVKP2x03Sj+RrCA==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.15.0.tgz",
+      "integrity": "sha512-yXjbt//E4T/ee8Ia1b5mGlbNj9fB9lJP4jqLbZualwpP2BCQ5is6BcWwxpIsY4XKAhmdv3hrW92GdtJbatC6dQ==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -710,13 +729,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.4.tgz",
-      "integrity": "sha512-ty8b5qHKatlNYd9vmpHooQz3Vki3gG+3PchmtsA4TgrZBKWHNjWfkQid7K7xQogBqqc7/BhGazxMD5vr6Ha+iQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.15.0.tgz",
+      "integrity": "sha512-7mVZJN7Hd15OmGuWrp2T9UvqR2Ecg+1j/Bp1jXUEY2GZKV6FXlOIoqVDmLpBiEiq3katvj/2n2mR0SDwtloCew==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.7.4",
-        "@typescript-eslint/visitor-keys": "6.7.4",
+        "@typescript-eslint/types": "6.15.0",
+        "@typescript-eslint/visitor-keys": "6.15.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -737,17 +756,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.7.4.tgz",
-      "integrity": "sha512-PRQAs+HUn85Qdk+khAxsVV+oULy3VkbH3hQ8hxLRJXWBEd7iI+GbQxH5SEUSH7kbEoTp6oT1bOwyga24ELALTA==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.15.0.tgz",
+      "integrity": "sha512-eF82p0Wrrlt8fQSRL0bGXzK5nWPRV2dYQZdajcfzOD9+cQz9O7ugifrJxclB+xVOvWvagXfqS4Es7vpLP4augw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.7.4",
-        "@typescript-eslint/types": "6.7.4",
-        "@typescript-eslint/typescript-estree": "6.7.4",
+        "@typescript-eslint/scope-manager": "6.15.0",
+        "@typescript-eslint/types": "6.15.0",
+        "@typescript-eslint/typescript-estree": "6.15.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -762,12 +781,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.4.tgz",
-      "integrity": "sha512-pOW37DUhlTZbvph50x5zZCkFn3xzwkGtNoJHzIM3svpiSkJzwOYr/kVBaXmf+RAQiUDs1AHEZVNPg6UJCJpwRA==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.15.0.tgz",
+      "integrity": "sha512-1zvtdC1a9h5Tb5jU9x3ADNXO9yjP8rXlaoChu0DQX40vf5ACVpYIVIZhIMZ6d5sDXH7vq4dsZBT1fEGj8D2n2w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.7.4",
+        "@typescript-eslint/types": "6.15.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -777,6 +796,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "dev": true
     },
     "node_modules/@vscode/python-extension": {
       "version": "1.0.5",
@@ -788,9 +813,9 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.5.tgz",
-      "integrity": "sha512-lAW7nQ0HuPqJnGJrtCzEKZCICtRizeP6qNanyCrjmdCOAAWjX3ixiG8RVPwqsYPQBWLPgYuE12qQlwXsOR/2fQ==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.8.tgz",
+      "integrity": "sha512-b4aZZsBKtMGdDljAsOPObnAi7+VWIaYl3ylCz1jTs+oV6BZ4TNHcVNC3xUn0azPeszBmwSBDQYfFESIaUQnrOg==",
       "dev": true,
       "dependencies": {
         "http-proxy-agent": "^4.0.1",
@@ -809,9 +834,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1103,6 +1128,18 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/builtins": {
       "version": "5.0.1",
@@ -1518,9 +1555,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.4.tgz",
-      "integrity": "sha512-x7jL0tbRRpv4QUyuDMjONtWFciygUxWaUM1kMX2zWxI0X2YWOt7MSA0g4UdeSiHM8fcYVzpQhKYOycZwxTdZkA==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.10.tgz",
+      "integrity": "sha512-S1Y27QGt/snkNYrRcswgRFqZjaTG5a5xM3EQo97uNBnH505pdzSNe/HLBq1v0RO7iK/ngdbhJB6mDAp0OK+iUA==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -1530,28 +1567,29 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.19.4",
-        "@esbuild/android-arm64": "0.19.4",
-        "@esbuild/android-x64": "0.19.4",
-        "@esbuild/darwin-arm64": "0.19.4",
-        "@esbuild/darwin-x64": "0.19.4",
-        "@esbuild/freebsd-arm64": "0.19.4",
-        "@esbuild/freebsd-x64": "0.19.4",
-        "@esbuild/linux-arm": "0.19.4",
-        "@esbuild/linux-arm64": "0.19.4",
-        "@esbuild/linux-ia32": "0.19.4",
-        "@esbuild/linux-loong64": "0.19.4",
-        "@esbuild/linux-mips64el": "0.19.4",
-        "@esbuild/linux-ppc64": "0.19.4",
-        "@esbuild/linux-riscv64": "0.19.4",
-        "@esbuild/linux-s390x": "0.19.4",
-        "@esbuild/linux-x64": "0.19.4",
-        "@esbuild/netbsd-x64": "0.19.4",
-        "@esbuild/openbsd-x64": "0.19.4",
-        "@esbuild/sunos-x64": "0.19.4",
-        "@esbuild/win32-arm64": "0.19.4",
-        "@esbuild/win32-ia32": "0.19.4",
-        "@esbuild/win32-x64": "0.19.4"
+        "@esbuild/aix-ppc64": "0.19.10",
+        "@esbuild/android-arm": "0.19.10",
+        "@esbuild/android-arm64": "0.19.10",
+        "@esbuild/android-x64": "0.19.10",
+        "@esbuild/darwin-arm64": "0.19.10",
+        "@esbuild/darwin-x64": "0.19.10",
+        "@esbuild/freebsd-arm64": "0.19.10",
+        "@esbuild/freebsd-x64": "0.19.10",
+        "@esbuild/linux-arm": "0.19.10",
+        "@esbuild/linux-arm64": "0.19.10",
+        "@esbuild/linux-ia32": "0.19.10",
+        "@esbuild/linux-loong64": "0.19.10",
+        "@esbuild/linux-mips64el": "0.19.10",
+        "@esbuild/linux-ppc64": "0.19.10",
+        "@esbuild/linux-riscv64": "0.19.10",
+        "@esbuild/linux-s390x": "0.19.10",
+        "@esbuild/linux-x64": "0.19.10",
+        "@esbuild/netbsd-x64": "0.19.10",
+        "@esbuild/openbsd-x64": "0.19.10",
+        "@esbuild/sunos-x64": "0.19.10",
+        "@esbuild/win32-arm64": "0.19.10",
+        "@esbuild/win32-ia32": "0.19.10",
+        "@esbuild/win32-x64": "0.19.10"
       }
     },
     "node_modules/escalade": {
@@ -1576,18 +1614,19 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.50.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.50.0.tgz",
-      "integrity": "sha512-FOnOGSuFuFLv/Sa+FDVRZl4GGVAAFFi8LecRsI5a1tMO5HIE8nCm4ivAlzt4dT3ol/PaaGC0rJEEXQmHJBGoOg==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
+      "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.50.0",
-        "@humanwhocodes/config-array": "^0.11.11",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.56.0",
+        "@humanwhocodes/config-array": "^0.11.13",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -1629,6 +1668,18 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-compat-utils": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.1.2.tgz",
+      "integrity": "sha512-Jia4JDldWnFNIru1Ehx1H5s9/yxiRHY/TimCuUc0jNexew3cF1gI6CYZil1ociakfWO3rRqFjl1mskBblB3RYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
     "node_modules/eslint-config-standard": {
       "version": "17.1.0",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.1.0.tgz",
@@ -1659,9 +1710,9 @@
       }
     },
     "node_modules/eslint-config-standard-with-typescript": {
-      "version": "39.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-39.1.0.tgz",
-      "integrity": "sha512-5+SPKis3yr6T1X6wSA7HhDuumTRMrTDMcsTrIWhdZuI+sX3e8SPGZYzuJxVxdc239Yo718dEVEVyJhHI6jUjrQ==",
+      "version": "43.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-43.0.0.tgz",
+      "integrity": "sha512-AT0qK01M5bmsWiE3UZvaQO5da1y1n6uQckAKqGNe6zPW5IOzgMLXZxw77nnFm+C11nxAZXsCPrbsgJhSrGfX6Q==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/parser": "^6.4.0",
@@ -1723,13 +1774,14 @@
       }
     },
     "node_modules/eslint-plugin-es-x": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.2.0.tgz",
-      "integrity": "sha512-9dvv5CcvNjSJPqnS5uZkqb3xmbeqRLnvXKK7iI5+oK/yTusyc46zbBZKENGsOfojm/mKfszyZb+wNqNPAPeGXA==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.5.0.tgz",
+      "integrity": "sha512-ODswlDSO0HJDzXU0XvgZ3lF3lS3XAZEossh15Q2UHjwrJggWeBoKqqEsLTZLXl+dh5eOAozG0zRcYtuE35oTuQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.1.2",
-        "@eslint-community/regexpp": "^4.6.0"
+        "@eslint-community/regexpp": "^4.6.0",
+        "eslint-compat-utils": "^0.1.2"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -1742,28 +1794,28 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.28.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.1.tgz",
-      "integrity": "sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
+      "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dev": true,
       "dependencies": {
-        "array-includes": "^3.1.6",
-        "array.prototype.findlastindex": "^1.2.2",
-        "array.prototype.flat": "^1.3.1",
-        "array.prototype.flatmap": "^1.3.1",
+        "array-includes": "^3.1.7",
+        "array.prototype.findlastindex": "^1.2.3",
+        "array.prototype.flat": "^1.3.2",
+        "array.prototype.flatmap": "^1.3.2",
         "debug": "^3.2.7",
         "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.7",
+        "eslint-import-resolver-node": "^0.3.9",
         "eslint-module-utils": "^2.8.0",
-        "has": "^1.0.3",
-        "is-core-module": "^2.13.0",
+        "hasown": "^2.0.0",
+        "is-core-module": "^2.13.1",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.6",
-        "object.groupby": "^1.0.0",
-        "object.values": "^1.1.6",
+        "object.fromentries": "^2.0.7",
+        "object.groupby": "^1.0.1",
+        "object.values": "^1.1.7",
         "semver": "^6.3.1",
-        "tsconfig-paths": "^3.14.2"
+        "tsconfig-paths": "^3.15.0"
       },
       "engines": {
         "node": ">=4"
@@ -1803,16 +1855,17 @@
       }
     },
     "node_modules/eslint-plugin-n": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.1.0.tgz",
-      "integrity": "sha512-3wv/TooBst0N4ND+pnvffHuz9gNPmk/NkLwAxOt2JykTl/hcuECe6yhTtLJcZjIxtZwN+GX92ACp/QTLpHA3Hg==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.5.0.tgz",
+      "integrity": "sha512-Hw02Bj1QrZIlKyj471Tb1jSReTl4ghIMHGuBGiMVmw+s0jOPbI4CBuYpGbZr+tdQ+VAvSK6FDSta3J4ib/SKHQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "builtins": "^5.0.1",
-        "eslint-plugin-es-x": "^7.1.0",
+        "eslint-plugin-es-x": "^7.5.0",
         "get-tsconfig": "^4.7.0",
         "ignore": "^5.2.4",
+        "is-builtin-module": "^3.2.1",
         "is-core-module": "^2.12.1",
         "minimatch": "^3.1.2",
         "resolve": "^1.22.2",
@@ -1934,9 +1987,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -2081,10 +2134,13 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.6",
@@ -2219,9 +2275,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.22.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.22.0.tgz",
-      "integrity": "sha512-H1Ddc/PbZHTDVJSnj8kWptIRSD6AM3pK+mKytuIVF4uoBV7rshFlhhvA58ceJ5wp3Er58w6zj7bykMpYXt3ETw==",
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -2404,6 +2460,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -2564,6 +2632,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-builtin-module": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+      "dev": true,
+      "dependencies": {
+        "builtin-modules": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -2577,12 +2660,12 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
-      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
       "dev": true,
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2897,7 +2980,7 @@
     "node_modules/license-checker": {
       "version": "1.0.0",
       "resolved": "git+ssh://git@github.com/mwittig/license-checker.git#d546e3f738e14c62e732346fa355162d46700893",
-      "integrity": "sha512-31msGNoOvPqtKa7Qo54iYkgLE9dalqSuIvQdWV5if2+oNyqh56WFT6fSsUZRWoGhZjXDhl+SV7Beb8PpfSUh8A==",
+      "integrity": "sha512-CeZEQfhSiqkTkY6wbGFBo3ki7iMSo4+m46xjZ0Ou84CbEu8fhoFaz8H8Nsr/KtPscdQeZNFgdgWWUPKikKDupg==",
       "dev": true,
       "dependencies": {
         "chalk": "~0.5.1",
@@ -3623,9 +3706,9 @@
       "dev": true
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -4176,9 +4259,9 @@
       }
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
-      "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
       "dev": true,
       "dependencies": {
         "@types/json5": "^0.0.29",
@@ -4286,9 +4369,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -4312,6 +4395,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/client/vscode/package-lock.json
+++ b/client/vscode/package-lock.json
@@ -13,28 +13,28 @@
         "vscode-languageclient": "^9.0.1"
       },
       "devDependencies": {
-        "@types/chai": "^4.3.6",
-        "@types/glob": "^8.0.0",
-        "@types/mocha": "^10.0.2",
-        "@types/node": "^20.8.2",
-        "@types/vscode": "^1.63.0",
-        "@typescript-eslint/eslint-plugin": "^6.7.4",
-        "@typescript-eslint/parser": "^6.7.4",
-        "@vscode/test-electron": "^2.3.5",
+        "@types/chai": "^4.3.11",
+        "@types/glob": "^8.1.0",
+        "@types/mocha": "^10.0.6",
+        "@types/node": "^20.10.5",
+        "@types/vscode": "^1.85.0",
+        "@typescript-eslint/eslint-plugin": "^6.15.0",
+        "@typescript-eslint/parser": "^6.15.0",
+        "@vscode/test-electron": "^2.3.8",
         "chai": "^4.3.10",
-        "esbuild": "^0.19.4",
-        "eslint": "^8.22.0",
-        "eslint-config-standard-with-typescript": "^39.1.0",
-        "eslint-plugin-import": "^2.26.0",
-        "eslint-plugin-n": "^16.1.0",
-        "eslint-plugin-promise": "^6.0.0",
+        "esbuild": "^0.19.10",
+        "eslint": "^8.56.0",
+        "eslint-config-standard-with-typescript": "^39.1.1",
+        "eslint-plugin-import": "^2.29.1",
+        "eslint-plugin-n": "^16.5.0",
+        "eslint-plugin-promise": "^6.1.1",
         "mocha": "^10.2.0",
         "npm-license-crawler": "^0.2.1",
-        "typescript": "^5.2.2"
+        "typescript": "^5.3.3"
       },
       "engines": {
-        "node": ">=16.17.1",
-        "vscode": "^1.83.0"
+        "node": ">=18.12.1",
+        "vscode": "^1.85.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -31,7 +31,7 @@
   "qna": "false",
   "engines": {
     "node": ">=16.17.1",
-    "vscode": "^1.85.0"
+    "vscode": "^1.83.0"
   },
   "extensionDependencies": [
     "ms-python.python"
@@ -162,23 +162,24 @@
     "@vscode/python-extension": "^1.0.5"
   },
   "devDependencies": {
-    "@types/chai": "^4.3.11",
-    "@types/glob": "^8.1.0",
-    "@types/mocha": "^10.0.6",
-    "@types/node": "^20.10.5",
-    "@types/vscode": "^1.85.0",
-    "@typescript-eslint/eslint-plugin": "^6.15.0",
-    "@typescript-eslint/parser": "^6.15.0",
-    "@vscode/test-electron": "^2.3.8",
+    "@types/chai": "^4.3.6",
+    "@types/glob": "^8.0.0",
+    "@types/mocha": "^10.0.2",
+    "@types/node": "^20.8.2",
+    "@types/vscode": "^1.63.0",
+    "@typescript-eslint/eslint-plugin": "^6.7.4",
+    "@typescript-eslint/parser": "^6.7.4",
+    "@vscode/test-electron": "^2.3.5",
     "chai": "^4.3.10",
-    "esbuild": "^0.19.10",
-    "eslint": "^8.56.0",
-    "eslint-config-standard-with-typescript": "^43.0.0",
-    "eslint-plugin-import": "^2.29.1",
-    "eslint-plugin-n": "^16.5.0",
-    "eslint-plugin-promise": "^6.1.1",
+    "esbuild": "^0.19.4",
+    "eslint": "^8.22.0",
+    "eslint-config-standard-with-typescript": "^39.1.0",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-n": "^16.1.0",
+    "eslint-plugin-promise": "^6.0.0",
     "mocha": "^10.2.0",
     "npm-license-crawler": "^0.2.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.2.2"
   }
 }
+

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -31,7 +31,7 @@
   "qna": "false",
   "engines": {
     "node": ">=16.17.1",
-    "vscode": "^1.83.0"
+    "vscode": "^1.85.0"
   },
   "extensionDependencies": [
     "ms-python.python"
@@ -162,23 +162,23 @@
     "@vscode/python-extension": "^1.0.5"
   },
   "devDependencies": {
-    "@types/chai": "^4.3.6",
-    "@types/glob": "^8.0.0",
-    "@types/mocha": "^10.0.2",
-    "@types/node": "^20.8.2",
-    "@types/vscode": "^1.63.0",
-    "@typescript-eslint/eslint-plugin": "^6.7.4",
-    "@typescript-eslint/parser": "^6.7.4",
-    "@vscode/test-electron": "^2.3.5",
+    "@types/chai": "^4.3.11",
+    "@types/glob": "^8.1.0",
+    "@types/mocha": "^10.0.6",
+    "@types/node": "^20.10.5",
+    "@types/vscode": "^1.85.0",
+    "@typescript-eslint/eslint-plugin": "^6.15.0",
+    "@typescript-eslint/parser": "^6.15.0",
+    "@vscode/test-electron": "^2.3.8",
     "chai": "^4.3.10",
-    "esbuild": "^0.19.4",
-    "eslint": "^8.22.0",
-    "eslint-config-standard-with-typescript": "^39.1.0",
-    "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-n": "^16.1.0",
-    "eslint-plugin-promise": "^6.0.0",
+    "esbuild": "^0.19.10",
+    "eslint": "^8.56.0",
+    "eslint-config-standard-with-typescript": "^43.0.0",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-n": "^16.5.0",
+    "eslint-plugin-promise": "^6.1.1",
     "mocha": "^10.2.0",
     "npm-license-crawler": "^0.2.1",
-    "typescript": "^5.2.2"
+    "typescript": "^5.3.3"
   }
 }

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -30,8 +30,8 @@
   ],
   "qna": "false",
   "engines": {
-    "node": ">=16.17.1",
-    "vscode": "^1.83.0"
+    "node": ">=18.12.1",
+    "vscode": "^1.85.0"
   },
   "extensionDependencies": [
     "ms-python.python"
@@ -162,24 +162,24 @@
     "@vscode/python-extension": "^1.0.5"
   },
   "devDependencies": {
-    "@types/chai": "^4.3.6",
-    "@types/glob": "^8.0.0",
-    "@types/mocha": "^10.0.2",
-    "@types/node": "^20.8.2",
-    "@types/vscode": "^1.63.0",
-    "@typescript-eslint/eslint-plugin": "^6.7.4",
-    "@typescript-eslint/parser": "^6.7.4",
-    "@vscode/test-electron": "^2.3.5",
+    "@types/chai": "^4.3.11",
+    "@types/glob": "^8.1.0",
+    "@types/mocha": "^10.0.6",
+    "@types/node": "^20.10.5",
+    "@types/vscode": "^1.85.0",
+    "@typescript-eslint/eslint-plugin": "^6.15.0",
+    "@typescript-eslint/parser": "^6.15.0",
+    "@vscode/test-electron": "^2.3.8",
     "chai": "^4.3.10",
-    "esbuild": "^0.19.4",
-    "eslint": "^8.22.0",
-    "eslint-config-standard-with-typescript": "^39.1.0",
-    "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-n": "^16.1.0",
-    "eslint-plugin-promise": "^6.0.0",
+    "esbuild": "^0.19.10",
+    "eslint": "^8.56.0",
+    "eslint-config-standard-with-typescript": "^39.1.1",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-n": "^16.5.0",
+    "eslint-plugin-promise": "^6.1.1",
     "mocha": "^10.2.0",
     "npm-license-crawler": "^0.2.1",
-    "typescript": "^5.2.2"
+    "typescript": "^5.3.3"
   }
 }
 

--- a/client/vscode/src/extension.ts
+++ b/client/vscode/src/extension.ts
@@ -143,17 +143,10 @@ async function getPythonPath(): Promise<string> {
     // make sure all environments are loaded
     await python.environments.refreshEnvironments();
 
-    for (const e of python.environments.known) {
-        console.log(`found ${e.executable.uri.fsPath}`);
-    }
-
-    console.log(`VIRTUAL_ENV=${process.env['VIRTUAL_ENV']}`);
-
     // use virtual env, if one is active
     const envPath = process.env['VIRTUAL_ENV'] || python.environments.getActiveEnvironmentPath().path;
 
     logger.debug(`Active environment path: ${envPath}`);
-    console.log(`Active environment path: ${envPath}`);
 
     const env = await python.environments.resolveEnvironment(envPath);
 
@@ -167,7 +160,6 @@ async function getPythonPath(): Promise<string> {
     }
 
     logger.info(`Using interpreter: ${pythonUri.fsPath}`);
-    console.log(`Using interpreter: ${pythonUri.fsPath}`);
 
     return pythonUri.fsPath;
 }

--- a/client/vscode/src/extension.ts
+++ b/client/vscode/src/extension.ts
@@ -143,10 +143,17 @@ async function getPythonPath(): Promise<string> {
     // make sure all environments are loaded
     await python.environments.refreshEnvironments();
 
+    for (const e of python.environments.known) {
+        console.log(`found ${e.executable.uri.fsPath}`);
+    }
+
+    console.log(`VIRTUAL_ENV=${process.env['VIRTUAL_ENV']}`);
+
     // use virtual env, if one is active
     const envPath = process.env['VIRTUAL_ENV'] || python.environments.getActiveEnvironmentPath().path;
 
     logger.debug(`Active environment path: ${envPath}`);
+    console.log(`Active environment path: ${envPath}`);
 
     const env = await python.environments.resolveEnvironment(envPath);
 
@@ -160,6 +167,7 @@ async function getPythonPath(): Promise<string> {
     }
 
     logger.info(`Using interpreter: ${pythonUri.fsPath}`);
+    console.log(`Using interpreter: ${pythonUri.fsPath}`);
 
     return pythonUri.fsPath;
 }

--- a/client/vscode/tests/definition.test.ts
+++ b/client/vscode/tests/definition.test.ts
@@ -18,13 +18,13 @@ describe('Should do definitions for step expressions, step implementation defini
         }
 
         const actual = await testDefintion(content, new vscode.Position(3, 26));
-        expect(actual.length).to.be.equal(1);
+        expect(actual.length, 'length is not 1').to.be.equal(1);
         const actual_definition = actual[0];
-        expect(actual_definition.targetUri.path.endsWith('grizzly/steps/scenario/tasks.py')).to.be.true;
-        expect(actual_definition.originSelectionRange.start.line).to.equal(3);
-        expect(actual_definition.originSelectionRange.start.character).to.equal(4);
-        expect(actual_definition.originSelectionRange.end.line).to.equal(3);
-        expect(actual_definition.originSelectionRange.end.character).to.equal(end);
+        expect(actual_definition.targetUri.path.endsWith('grizzly/steps/scenario/tasks/request.py'), `targetUri is not expected: ${actual_definition.targetUri}`).to.be.true;
+        expect(actual_definition.originSelectionRange.start.line, `originSelectionRange.start.line is not as expected: ${actual_definition.originSelectionRange.start.line}`).to.equal(3);
+        expect(actual_definition.originSelectionRange.start.character, `originSelectionRange.start.character is not as expected: ${actual_definition.originSelectionRange.start.character}`).to.equal(4);
+        expect(actual_definition.originSelectionRange.end.line, `originSelectionRange.end.line is not as expected: ${actual_definition.originSelectionRange.end.line}`).to.equal(3);
+        expect(actual_definition.originSelectionRange.end.character, `originSelectionRange.end.character is not as expected: ${actual_definition.originSelectionRange.end.character}`).to.equal(end);
     });
 
     it('Request payload reference in step does exist in features/requests', async () => {

--- a/client/vscode/tests/helper.ts
+++ b/client/vscode/tests/helper.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
+import { expect } from 'chai';
 
 export let doc: vscode.TextDocument | undefined = undefined;
 export let editor: vscode.TextEditor | undefined = undefined;
@@ -50,4 +51,19 @@ export const getDocUri = (p: string) => {
 async function setTestContent(content: string): Promise<boolean> {
     const all = new vscode.Range(doc.positionAt(0), doc.positionAt(doc.getText().length));
     return editor.edit((eb) => eb.replace(all, content));
+}
+
+export async function acceptAndAssertSuggestion(position: vscode.Position, expected: string): Promise<void> {
+    // move cursor
+    editor.selection = new vscode.Selection(position, position);
+
+    const time = 50;
+    vscode.commands.executeCommand('editor.action.triggerSuggest');
+    await sleep(time);
+    vscode.commands.executeCommand('acceptSelectedSuggestion');
+    await sleep(time);
+    const buffer = vscode.window.activeTextEditor.document.getText();
+    const actual = buffer.split(/\r?\n/)[position.line];
+
+    expect(actual).to.be.equal(expected);
 }

--- a/client/vscode/tests/helper.ts
+++ b/client/vscode/tests/helper.ts
@@ -25,6 +25,7 @@ export async function activate(docUri: vscode.Uri, content: string) {
         // if the extension for some reason won't start, it is nice to look at the output
         // to be able to understand why
         if (ext.exports === undefined) {
+            console.error('extension did not start');
             await sleep(1000*60*60*24);
         }
 

--- a/client/vscode/tests/hover.test.ts
+++ b/client/vscode/tests/hover.test.ts
@@ -29,12 +29,11 @@ describe('Should show help on hover step expression', () => {
         expect(actual.range?.end.character).to.be.equal(end);
         const contents = actual.contents[0] as vscode.MarkdownString;
         expect(contents.value).to.be
-            .equal(`Sets which type of users the scenario should use and which \`host\` is the target,
+            .equal(`Set which type of users the scenario should use and which \`host\` is the target,
 together with \`weight\` of the user (how many instances of this user should spawn relative to others).
 
 Example:
-
-\`\`\` gherkin
+\`\`\`gherkin
 Given a user of type "RestApi" with weight "2" load testing "..."
 Given a user of type "MessageQueue" with weight "1" load testing "..."
 Given a user of type "ServiceBus" with weight "1" load testing "..."
@@ -75,8 +74,7 @@ Args:
 Default behavior is to continue the scenario if a request fails.
 
 Example:
-
-\`\`\` gherkin
+\`\`\`gherkin
 And restart scenario on failure
 \`\`\`
 `);

--- a/client/vscode/tests/index.ts
+++ b/client/vscode/tests/index.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import * as Mocha from 'mocha';
 import * as glob from 'glob';
-import * as vscode from 'vscode';
 
 export function run(): Promise<void> {
     // Create the mocha test
@@ -14,7 +13,7 @@ export function run(): Promise<void> {
     const testsRoot = __dirname;
 
     return new Promise((resolve, reject) => {
-        const tests = process.env['TESTS']?.split(',');
+        const tests = process.env['TESTS']?.split(',').map((test) => path.parse(test.replace('.ts', '.js')).base);
         glob('**.test.js', { cwd: testsRoot }, (err: Error, files: string[]) => {
             if (err) {
                 return reject(err);
@@ -22,12 +21,12 @@ export function run(): Promise<void> {
 
             // Add files to the test suite
             files.forEach((f: string) => {
-                if ((tests === undefined || tests.includes(`${path.parse(f).name}.ts`))) {
+                if (tests === undefined || tests.includes(f)) {
                     mocha.addFile(path.resolve(testsRoot, f));
                 }
-
-                return;
             });
+
+            mocha.slow(150);
 
             try {
                 // Run the mocha test

--- a/client/vscode/tests/runTest.ts
+++ b/client/vscode/tests/runTest.ts
@@ -67,7 +67,7 @@ async function installExtension(vscodeExecutablePath: string, extensionId: strin
 async function main() {
     try {
 
-        const vscodeExecutablePath = await downloadAndUnzipVSCode('1.83.1');
+        const vscodeExecutablePath = await downloadAndUnzipVSCode();
         const extensionDevelopmentPathExtra = await installExtension(vscodeExecutablePath, 'ms-python.python');
 
         // The folder containing the Extension Manifest package.json

--- a/client/vscode/tests/runTest.ts
+++ b/client/vscode/tests/runTest.ts
@@ -38,7 +38,7 @@ async function installExtension(vscodeExecutablePath: string, extensionId: strin
         const extensionDir = path.join(possibleExtensionPath, 'extensions');
         try {
             await fs.access(extensionDir);
-        } catch {
+        } catch { // weird... but hey, let's cover it
             continue;
         }
         const extensions = (await fs.readdir(extensionDir, {withFileTypes: true})).filter(dir => dir.isDirectory()).map(dir => dir.name)

--- a/client/vscode/tests/runTest.ts
+++ b/client/vscode/tests/runTest.ts
@@ -67,7 +67,7 @@ async function installExtension(vscodeExecutablePath: string, extensionId: strin
 async function main() {
     try {
 
-        const vscodeExecutablePath = await downloadAndUnzipVSCode();
+        const vscodeExecutablePath = await downloadAndUnzipVSCode('1.83.1');
         const extensionDevelopmentPathExtra = await installExtension(vscodeExecutablePath, 'ms-python.python');
 
         // The folder containing the Extension Manifest package.json

--- a/client/vscode/tests/runTest.ts
+++ b/client/vscode/tests/runTest.ts
@@ -36,6 +36,11 @@ async function installExtension(vscodeExecutablePath: string, extensionId: strin
         }
 
         const extensionDir = path.join(possibleExtensionPath, 'extensions');
+        try {
+            await fs.access(extensionDir);
+        } catch {
+            continue;
+        }
         const extensions = (await fs.readdir(extensionDir, {withFileTypes: true})).filter(dir => dir.isDirectory()).map(dir => dir.name)
             .filter(name => name.startsWith(extensionId));
 

--- a/grizzly-ls/src/grizzly_ls/server/__init__.py
+++ b/grizzly-ls/src/grizzly_ls/server/__init__.py
@@ -235,7 +235,7 @@ def install(ls: GrizzlyLanguageServer, *args: Any) -> None:
     with Progress(ls.progress, 'grizzly-ls') as progress:
         # <!-- should a virtual environment be used?
         use_venv = ls.client_settings.get('use_virtual_environment', True)
-        executable = 'python3' if use_venv else sys.executable
+        executable = 'python' if use_venv else sys.executable
         # // -->
 
         ls.logger.debug(f'workspace root: {ls.root_path}')

--- a/grizzly-ls/src/grizzly_ls/server/__init__.py
+++ b/grizzly-ls/src/grizzly_ls/server/__init__.py
@@ -29,8 +29,6 @@ from pip._internal.configuration import Configuration as PipConfiguration
 from pip._internal.exceptions import ConfigurationError as PipConfigurationError
 from time import sleep
 
-import gevent.monkey  # type: ignore
-
 from pygls.server import LanguageServer
 from pygls.capabilities import get_capability
 from lsprotocol import types as lsp
@@ -109,7 +107,12 @@ class GrizzlyLanguageServer(LanguageServer):
         self.language = 'en'  # assumed default
 
         # monkey patch functions to short-circuit them (causes problems in this context)
-        gevent.monkey.patch_all = lambda: None
+        try:
+            import gevent.monkey  # type: ignore
+
+            gevent.monkey.patch_all = lambda: None
+        except ModuleNotFoundError:
+            pass
 
         def _signal(signum: Union[int, signal.Signals], frame: FrameType) -> None:
             return

--- a/grizzly-ls/src/grizzly_ls/server/features/code_actions.py
+++ b/grizzly-ls/src/grizzly_ls/server/features/code_actions.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 def quick_fix_no_step_impl(
-    ls: GrizzlyLanguageServer, diagnostic: lsp.Diagnostic
+    ls: GrizzlyLanguageServer, diagnostic: lsp.Diagnostic, text_document: TextDocument
 ) -> Optional[lsp.CodeAction]:
     files = sorted(
         [
@@ -54,7 +54,9 @@ def quick_fix_no_step_impl(
         return None
 
     try:
-        keyword_key = ls.get_language_key(keyword)
+        base_keyword = ls.get_base_keyword(diagnostic.range.start, text_document)
+
+        keyword_key = ls.get_language_key(base_keyword)
 
         variable_matches = list(
             re.finditer(r'"([^"]*)"', expression or '', flags=re.MULTILINE)
@@ -219,7 +221,7 @@ def generate_quick_fixes(
     for diagnostic in diagnostics:
         quick_fix: Optional[Union[lsp.CodeAction, List[lsp.CodeAction]]] = None
         if diagnostic.message.startswith(MARKER_NO_STEP_IMPL):
-            quick_fix = quick_fix_no_step_impl(ls, diagnostic)
+            quick_fix = quick_fix_no_step_impl(ls, diagnostic, text_document)
         elif diagnostic.message.endswith(MARKER_LANG_NOT_VALID):
             quick_fix = quick_fix_lang_not_valid(text_document, diagnostic)
         elif diagnostic.message.endswith(MARKER_LANG_WRONG_LINE):

--- a/grizzly-ls/src/grizzly_ls/server/features/diagnostics.py
+++ b/grizzly-ls/src/grizzly_ls/server/features/diagnostics.py
@@ -138,18 +138,19 @@ def validate_gherkin(
         # check if keywords are valid in the specified language
         lang_key: Optional[str] = None
         if keyword is not None:
-            if keyword.endswith(':'):
-                keyword = keyword[:-1]
+            start_position = lsp.Position(line=lineno, character=position)
+            keyword = keyword.rstrip(' :')
+            base_keyword = ls.get_base_keyword(start_position, text_document)
 
             try:
-                lang_key = ls.get_language_key(keyword)
+                lang_key = ls.get_language_key(base_keyword)
             except ValueError:
                 name = ls.localizations.get('name', ['unknown'])[0]
 
                 diagnostics.append(
                     lsp.Diagnostic(
                         range=lsp.Range(
-                            start=lsp.Position(line=lineno, character=position),
+                            start=start_position,
                             end=lsp.Position(
                                 line=lineno, character=position + len(keyword)
                             ),

--- a/grizzly-ls/src/grizzly_ls/server/inventory.py
+++ b/grizzly-ls/src/grizzly_ls/server/inventory.py
@@ -124,9 +124,14 @@ def compile_inventory(ls: GrizzlyLanguageServer) -> None:
 
     try:
         ls.behave_steps.clear()
-        ls.behave_steps = load_step_registry(
-            [path.parent for path in ls.root_path.rglob('*.py')]
-        )
+        # only include paths that doesn't contain [unix] hidden directories
+        paths = [
+            path.parent
+            for path in ls.root_path.rglob('*.py')
+            if path.parent.is_dir() and '.' not in path.parent.as_posix()
+        ]
+        logger.debug(f'loading steps from {paths}')
+        ls.behave_steps = load_step_registry(paths)
     except Exception as e:
         ls.show_message(
             f'unable to load behave step expressions:\n{str(e)}',

--- a/grizzly-ls/src/grizzly_ls/server/inventory.py
+++ b/grizzly-ls/src/grizzly_ls/server/inventory.py
@@ -212,9 +212,13 @@ def compile_keyword_inventory(ls: GrizzlyLanguageServer) -> None:
     )
 
     ls.keywords_headers = []
+    ls.keywords_all = []
     for key, values in ls.localizations.items():
         if values[0] != u'*':
             ls.keywords_headers.extend([*ls.localizations.get(key, [])])
+            ls.keywords_all.extend([*values])
+        else:
+            ls.keywords_all.extend([*values[1:]])
 
     # localized keywords
     ls.keywords = list(

--- a/grizzly-ls/src/grizzly_ls/utils.py
+++ b/grizzly-ls/src/grizzly_ls/utils.py
@@ -13,6 +13,7 @@ def run_command(
     env: Optional[Dict[str, str]] = None,
     cwd: Optional[str] = None,
 ) -> Tuple[int, List[str]]:
+    logger.debug(f'executing command: {" ".join(command)}')
     output: List[str] = []
 
     if env is None:
@@ -39,7 +40,10 @@ def run_command(
             if not buffer:
                 break
 
-            output.append(buffer.decode('utf-8'))
+            try:
+                output.append(buffer.decode())
+            except Exception:
+                logger.exception(buffer)
 
         process.terminate()
     except KeyboardInterrupt:  # pragma: no cover

--- a/grizzly-ls/tests/e2e/server/features/test_hover.py
+++ b/grizzly-ls/tests/e2e/server/features/test_hover.py
@@ -49,12 +49,11 @@ def test_hover(lsp_fixture: LspFixture) -> None:
     assert response.contents.kind == lsp.MarkupKind.Markdown
     assert (
         response.contents.value
-        == '''Sets which type of users the scenario should use and which `host` is the target,
+        == '''Set which type of users the scenario should use and which `host` is the target,
 together with `weight` of the user (how many instances of this user should spawn relative to others).
 
 Example:
-
-``` gherkin
+```gherkin
 Given a user of type "RestApi" with weight "2" load testing "..."
 Given a user of type "MessageQueue" with weight "1" load testing "..."
 Given a user of type "ServiceBus" with weight "1" load testing "..."

--- a/grizzly-ls/tests/fixtures.py
+++ b/grizzly-ls/tests/fixtures.py
@@ -63,6 +63,7 @@ class LspFixture:
         server.loop = asyncio.new_event_loop()
 
         self.server = server
+        self.server.language = 'en'
         self._server_thread = Thread(
             target=start, args=(self.server, cstdio, sstdout), daemon=True
         )

--- a/grizzly-ls/tests/unit/server/feature/test_code_actions.py
+++ b/grizzly-ls/tests/unit/server/feature/test_code_actions.py
@@ -26,190 +26,207 @@ def test_quick_fix_no_step_impl(lsp_fixture: LspFixture, mocker: MockerFixture) 
     ls.root_path = GRIZZLY_PROJECT
     expected_quick_fix_file = GRIZZLY_PROJECT / 'steps' / 'steps.py'
 
-    # <!-- "And"
-    diagnostic = lsp.Diagnostic(
-        range=lsp.Range(
-            start=lsp.Position(line=0, character=0),
-            end=lsp.Position(line=0, character=0),
-        ),
-        message=f'{MARKER_NO_STEP_IMPL}:\nAnd hello world',
-        severity=lsp.DiagnosticSeverity.Warning,
-        source='Dummy',
+    feature_file = (
+        lsp_fixture.datadir / 'features' / 'test_quick_fix_no_step_impl.feature'
     )
 
-    # no template
+    text_document = TextDocument(feature_file.as_uri())
+
     try:
-        del ls.client_settings['quick_fix']
-    except KeyError:
-        pass
+        # <!-- "And"
+        feature_file.write_text(
+            """Given foobar
+"""
+        )
+        diagnostic = lsp.Diagnostic(
+            range=lsp.Range(
+                start=lsp.Position(line=1, character=0),
+                end=lsp.Position(line=1, character=0),
+            ),
+            message=f'{MARKER_NO_STEP_IMPL}:\nAnd hello world',
+            severity=lsp.DiagnosticSeverity.Warning,
+            source='Dummy',
+        )
 
-    assert quick_fix_no_step_impl(ls, diagnostic) is None
+        # no template
+        try:
+            del ls.client_settings['quick_fix']
+        except KeyError:
+            pass
 
-    ls.client_settings.update(
-        {'quick_fix': {'step_impl_template': "@{keyword}(u'{expression}')"}}
-    )
+        assert quick_fix_no_step_impl(ls, diagnostic, text_document) is None
 
-    # no quick fix file
-    ls.root_path = Path('/tmp/asdf')
-    assert quick_fix_no_step_impl(ls, diagnostic) is None
+        ls.client_settings.update(
+            {'quick_fix': {'step_impl_template': "@{keyword}(u'{expression}')"}}
+        )
 
-    # all good
-    ls.root_path = GRIZZLY_PROJECT
+        # no quick fix file
+        ls.root_path = Path('/tmp/asdf')
+        assert quick_fix_no_step_impl(ls, diagnostic, text_document) is None
 
-    quick_fix = quick_fix_no_step_impl(ls, diagnostic)
-    assert quick_fix is not None
+        # all good
+        ls.root_path = GRIZZLY_PROJECT
 
-    assert quick_fix.title == 'Create step implementation'
-    assert quick_fix.kind == lsp.CodeActionKind.QuickFix
-    assert quick_fix.diagnostics == [diagnostic]
-    assert quick_fix.command == lsp.Command(
-        'Rebuild step inventory', 'grizzly.server.inventory.rebuild'
-    )
+        quick_fix = quick_fix_no_step_impl(ls, diagnostic, text_document)
+        assert quick_fix is not None
 
-    actual_edit = quick_fix.edit
-    assert isinstance(actual_edit, lsp.WorkspaceEdit)
-    assert actual_edit.changes is not None
+        assert quick_fix.title == 'Create step implementation'
+        assert quick_fix.kind == lsp.CodeActionKind.QuickFix
+        assert quick_fix.diagnostics == [diagnostic]
+        assert quick_fix.command == lsp.Command(
+            'Rebuild step inventory', 'grizzly.server.inventory.rebuild'
+        )
 
-    actual_changes = actual_edit.changes.get(expected_quick_fix_file.as_uri(), None)
-    assert actual_changes is not None
-    assert len(actual_changes) == 1
-    actual_text_edit = actual_changes[0]
-    assert (
-        actual_text_edit.new_text
-        == '''
-@step(u'hello world')
+        actual_edit = quick_fix.edit
+        assert isinstance(actual_edit, lsp.WorkspaceEdit)
+        assert actual_edit.changes is not None
+
+        actual_changes = actual_edit.changes.get(expected_quick_fix_file.as_uri(), None)
+        assert actual_changes is not None
+        assert len(actual_changes) == 1
+        actual_text_edit = actual_changes[0]
+        assert (
+            actual_text_edit.new_text
+            == '''
+@given(u'hello world')
 def step_impl(context: Context) -> None:
     raise NotImplementedError('no step implementation')
 '''
-    )
+        )
 
-    source = expected_quick_fix_file.read_text().splitlines()
-    expected_position = lsp.Position(line=len(source), character=0)
+        source = expected_quick_fix_file.read_text().splitlines()
+        expected_position = lsp.Position(line=len(source), character=0)
 
-    assert actual_text_edit.range == lsp.Range(
-        start=expected_position, end=expected_position
-    )
-    # // -->
+        assert actual_text_edit.range == lsp.Range(
+            start=expected_position, end=expected_position
+        )
+        # // -->
 
-    # <!-- Given
-    diagnostic = lsp.Diagnostic(
-        range=lsp.Range(
-            start=lsp.Position(line=0, character=0),
-            end=lsp.Position(line=0, character=0),
-        ),
-        message=f'{MARKER_NO_STEP_IMPL}:\nGiven a whole lot of cash',
-        severity=lsp.DiagnosticSeverity.Warning,
-        source='Dummy',
-    )
+        # <!-- Given
+        diagnostic = lsp.Diagnostic(
+            range=lsp.Range(
+                start=lsp.Position(line=0, character=0),
+                end=lsp.Position(line=0, character=0),
+            ),
+            message=f'{MARKER_NO_STEP_IMPL}:\nGiven a whole lot of cash',
+            severity=lsp.DiagnosticSeverity.Warning,
+            source='Dummy',
+        )
 
-    ls.client_settings.update(
-        {'quick_fix': {'step_impl_template': "@step({keyword}, en=u'{expression}')"}}
-    )
+        ls.client_settings.update(
+            {
+                'quick_fix': {
+                    'step_impl_template': "@step({keyword}, en=u'{expression}')"
+                }
+            }
+        )
 
-    quick_fix = quick_fix_no_step_impl(ls, diagnostic)
-    assert quick_fix is not None
+        quick_fix = quick_fix_no_step_impl(ls, diagnostic, text_document)
+        assert quick_fix is not None
 
-    assert quick_fix.title == 'Create step implementation'
-    assert quick_fix.kind == lsp.CodeActionKind.QuickFix
-    assert quick_fix.diagnostics == [diagnostic]
-    assert quick_fix.command == lsp.Command(
-        'Rebuild step inventory', 'grizzly.server.inventory.rebuild'
-    )
+        assert quick_fix.title == 'Create step implementation'
+        assert quick_fix.kind == lsp.CodeActionKind.QuickFix
+        assert quick_fix.diagnostics == [diagnostic]
+        assert quick_fix.command == lsp.Command(
+            'Rebuild step inventory', 'grizzly.server.inventory.rebuild'
+        )
 
-    actual_edit = quick_fix.edit
-    assert isinstance(actual_edit, lsp.WorkspaceEdit)
-    assert actual_edit.changes is not None
+        actual_edit = quick_fix.edit
+        assert isinstance(actual_edit, lsp.WorkspaceEdit)
+        assert actual_edit.changes is not None
 
-    actual_changes = actual_edit.changes.get(expected_quick_fix_file.as_uri(), None)
-    assert actual_changes is not None
-    assert len(actual_changes) == 1
-    actual_text_edit = actual_changes[0]
-    assert (
-        actual_text_edit.new_text
-        == '''
+        actual_changes = actual_edit.changes.get(expected_quick_fix_file.as_uri(), None)
+        assert actual_changes is not None
+        assert len(actual_changes) == 1
+        actual_text_edit = actual_changes[0]
+        assert (
+            actual_text_edit.new_text
+            == '''
 @step(given, en=u'a whole lot of cash')
 def step_impl(context: Context) -> None:
     raise NotImplementedError('no step implementation')
 '''
-    )
+        )
 
-    source = expected_quick_fix_file.read_text().splitlines()
-    expected_position = lsp.Position(line=len(source), character=0)
+        source = expected_quick_fix_file.read_text().splitlines()
+        expected_position = lsp.Position(line=len(source), character=0)
 
-    assert actual_text_edit.range == lsp.Range(
-        start=expected_position, end=expected_position
-    )
-    # // -->
+        assert actual_text_edit.range == lsp.Range(
+            start=expected_position, end=expected_position
+        )
+        # // -->
 
-    # <!-- no a valid gherkin expression
-    diagnostic = lsp.Diagnostic(
-        range=lsp.Range(
-            start=lsp.Position(line=0, character=0),
-            end=lsp.Position(line=0, character=0),
-        ),
-        message=f'{MARKER_NO_STEP_IMPL}:\nIf',
-        severity=lsp.DiagnosticSeverity.Warning,
-        source='Dummy',
-    )
+        # <!-- no a valid gherkin expression
+        diagnostic = lsp.Diagnostic(
+            range=lsp.Range(
+                start=lsp.Position(line=0, character=0),
+                end=lsp.Position(line=0, character=0),
+            ),
+            message=f'{MARKER_NO_STEP_IMPL}:\nIf',
+            severity=lsp.DiagnosticSeverity.Warning,
+            source='Dummy',
+        )
 
-    assert quick_fix_no_step_impl(ls, diagnostic) is None
-    # // -->
+        assert quick_fix_no_step_impl(ls, diagnostic, text_document) is None
+        # // -->
 
-    # <!-- with arguments
-    mocker.patch(
-        'random_word.RandomWords.get_random_word',
-        return_value='foobar',
-    )
-    diagnostic = lsp.Diagnostic(
-        range=lsp.Range(
-            start=lsp.Position(line=0, character=0),
-            end=lsp.Position(line=0, character=0),
-        ),
-        message=f'{MARKER_NO_STEP_IMPL}:\nGiven a "book" with "100" pages',
-        severity=lsp.DiagnosticSeverity.Warning,
-        source='Dummy',
-    )
+        # <!-- with arguments
+        mocker.patch(
+            'random_word.RandomWords.get_random_word',
+            return_value='foobar',
+        )
+        diagnostic = lsp.Diagnostic(
+            range=lsp.Range(
+                start=lsp.Position(line=0, character=0),
+                end=lsp.Position(line=0, character=0),
+            ),
+            message=f'{MARKER_NO_STEP_IMPL}:\nGiven a "book" with "100" pages',
+            severity=lsp.DiagnosticSeverity.Warning,
+            source='Dummy',
+        )
 
-    quick_fix = quick_fix_no_step_impl(ls, diagnostic)
-    assert quick_fix is not None
+        quick_fix = quick_fix_no_step_impl(ls, diagnostic, text_document)
+        assert quick_fix is not None
 
-    assert quick_fix.title == 'Create step implementation'
-    assert quick_fix.kind == lsp.CodeActionKind.QuickFix
-    assert quick_fix.diagnostics == [diagnostic]
-    assert quick_fix.command == lsp.Command(
-        'Rebuild step inventory', 'grizzly.server.inventory.rebuild'
-    )
+        assert quick_fix.title == 'Create step implementation'
+        assert quick_fix.kind == lsp.CodeActionKind.QuickFix
+        assert quick_fix.diagnostics == [diagnostic]
+        assert quick_fix.command == lsp.Command(
+            'Rebuild step inventory', 'grizzly.server.inventory.rebuild'
+        )
 
-    actual_edit = quick_fix.edit
-    assert isinstance(actual_edit, lsp.WorkspaceEdit)
-    assert actual_edit.changes is not None
+        actual_edit = quick_fix.edit
+        assert isinstance(actual_edit, lsp.WorkspaceEdit)
+        assert actual_edit.changes is not None
 
-    actual_changes = actual_edit.changes.get(expected_quick_fix_file.as_uri(), None)
-    assert actual_changes is not None
-    assert len(actual_changes) == 1
-    actual_text_edit = actual_changes[0]
-    assert (
-        actual_text_edit.new_text
-        == '''
+        actual_changes = actual_edit.changes.get(expected_quick_fix_file.as_uri(), None)
+        assert actual_changes is not None
+        assert len(actual_changes) == 1
+        actual_text_edit = actual_changes[0]
+        assert (
+            actual_text_edit.new_text
+            == '''
 @step(given, en=u'a "{book}" with "{foobar}" pages')
 def step_impl(context: Context, book: str, foobar: str) -> None:
     raise NotImplementedError('no step implementation')
 '''
-    )
+        )
 
-    source = expected_quick_fix_file.read_text().splitlines()
-    expected_position = lsp.Position(line=len(source), character=0)
+        source = expected_quick_fix_file.read_text().splitlines()
+        expected_position = lsp.Position(line=len(source), character=0)
 
-    assert actual_text_edit.range == lsp.Range(
-        start=expected_position, end=expected_position
-    )
-    # // -->
+        assert actual_text_edit.range == lsp.Range(
+            start=expected_position, end=expected_position
+        )
+        # // -->
 
-    # <!-- error...
-    mocker.patch.object(ls, 'get_language_key', side_effect=ValueError)
+        # <!-- error...
+        mocker.patch.object(ls, 'get_language_key', side_effect=ValueError)
 
-    assert quick_fix_no_step_impl(ls, diagnostic) is None
-    # // -->
+        assert quick_fix_no_step_impl(ls, diagnostic, text_document) is None
+        # // -->
+    finally:
+        feature_file.unlink()
 
 
 def test_quick_fix_lang_not_valid() -> None:
@@ -446,7 +463,9 @@ Feature: hello
     quick_fixes = generate_quick_fixes(ls, text_document, diagnostics)
     assert quick_fixes is not None
     assert len(quick_fixes) == 3
-    quick_fix_no_step_impl_mock.assert_called_once_with(ls, diagnostics[2])
+    quick_fix_no_step_impl_mock.assert_called_once_with(
+        ls, diagnostics[2], text_document
+    )
     quick_fix_lang_wrong_line_mock.assert_called_once_with(
         text_document, diagnostics[0]
     )

--- a/grizzly-ls/tests/unit/server/feature/test_diagnostics.py
+++ b/grizzly-ls/tests/unit/server/feature/test_diagnostics.py
@@ -183,44 +183,47 @@ Feature:
     # // -->
 
     # <!-- "complex" document with no errors
-    ls.language = 'sv'
-    text_document = TextDocument(
-        'file://test.feature',
-        '''# language: sv
-# testspecifikation: https://test.nu/specifikation/T01
-Egenskap: T01
-    """
-    lite text
-    bara
-    """
-    Scenario: test
-        Givet en tabell
-        # denna tabell mappar en nyckel med ett värde
-        | nyckel | värde |
-        | foo    | bar   |
-        | bar    | foo   |
-
-        Och följande fråga
+    try:
+        ls.language = 'sv'
+        text_document = TextDocument(
+            'file://test.feature',
+            '''# language: sv
+    # testspecifikation: https://test.nu/specifikation/T01
+    Egenskap: T01
         """
-        SELECT key, value FROM [dbo].[tests]
+        lite text
+        bara
         """
+        Scenario: test
+            Givet en tabell
+            # denna tabell mappar en nyckel med ett värde
+            | nyckel | värde |
+            | foo    | bar   |
+            | bar    | foo   |
 
-        Så producera ett dokument i formatet "json"
-''',
-    )
+            Och följande fråga
+            """
+            SELECT key, value FROM [dbo].[tests]
+            """
 
-    ls.steps.update(
-        {
-            'then': [
-                Step('then', 'producera ett dokument i formatet "json"', func=noop),
-                Step('then', 'producera ett dokument i formatet "xml"', func=noop),
-                Step('then', 'producera ett dokument i formatet "docx"', func=noop),
-            ],
-            'given': [Step('given', 'en tabell', func=noop)],
-            'step': [Step('step', 'följande fråga', func=noop)],
-        }
-    )
-    diagnostics = validate_gherkin(ls, text_document)
+            Så producera ett dokument i formatet "json"
+    ''',
+        )
 
-    assert diagnostics == []
+        ls.steps.update(
+            {
+                'then': [
+                    Step('then', 'producera ett dokument i formatet "json"', func=noop),
+                    Step('then', 'producera ett dokument i formatet "xml"', func=noop),
+                    Step('then', 'producera ett dokument i formatet "docx"', func=noop),
+                ],
+                'given': [Step('given', 'en tabell', func=noop)],
+                'step': [Step('step', 'följande fråga', func=noop)],
+            }
+        )
+        diagnostics = validate_gherkin(ls, text_document)
+
+        assert diagnostics == []
+    finally:
+        ls.language = 'en'
     # // -->

--- a/script/install.sh
+++ b/script/install.sh
@@ -10,13 +10,13 @@ main() {
     if [[ -z "${what}" || "${what}" == "server" ]]; then
         local args="-e"
         pushd "${script_dir}/../grizzly-ls" &> /dev/null
-        touch setup.cfg
         if [[ -n "${*}" && "${*}" == *"+e"* ]]; then
             args=""
         fi
-        python3 -m pip install $args .[dev] || { rm setup.cfg; exit 1; }
-        rm setup.cfg
+        python -m pip install $args .[dev] || { exit 1; }
         popd &> /dev/null
+
+        python -c 'import sys; print(sys.executable)'
     fi
 
     if [[ -z "${what}" || "${what}" == "client/"* ]]; then

--- a/script/install.sh
+++ b/script/install.sh
@@ -15,8 +15,6 @@ main() {
         fi
         python -m pip install $args .[dev] || { exit 1; }
         popd &> /dev/null
-
-        python -c 'import sys; print(sys.executable)'
     fi
 
     if [[ -z "${what}" || "${what}" == "client/"* ]]; then

--- a/tests/project/.vscode/settings.json
+++ b/tests/project/.vscode/settings.json
@@ -1,5 +1,10 @@
 {
-	"[grizzly-gherkin]": {
-		"editor.links": false
-	}
+  "grizzly.stdio.args": [
+    "--verbose",
+    "--no-verbose",
+    "pygls"
+  ],
+  "[grizzly-gherkin]": {
+    "editor.links": false
+  }
 }


### PR DESCRIPTION
fixed problem in Biometria-se/grizzly#296.
    
implemented better support for `And` and `But`, since they depend on a non-"one of those" steps arbritary number of lines above. now when completing with those, it will only return suggestions related to the identified "base" keyword above it, instead of all.
    
`client/vscode` completion tests has been greatly approved by actually accepting a suggestion and verifying that the completef line turned out as expected. that is a hack though, since there are no events to listen for that would tell you that the UI is done, so sleeps are introduced :(
 
`ms-python.python` and it's `@vscode/python-extension` API is buggy when it comes to selecting python environment, seems like it does not take which python environment that is active when executing into consideration at all.

workaround this in the extension by looking if `VIRTUAL_ENV` environment variable is set, and use the value of that to resolve the environment used.

in the workflow `action/setup-python` will set environment variable `pythonLocation` for the environment that is configured. so when running the client test we set `VIRTUAL_ENV` to the value of `pythonLocation`.