### PR TITLE
support for grizzly `{% scenario ... %}` tag

### DIFF
--- a/grizzly-ls/pyproject.toml
+++ b/grizzly-ls/pyproject.toml
@@ -83,7 +83,6 @@ root = ".."
 timeout = 300
 addopts = [
     "--rootdir=grizzly-ls/",
-    "-o", "testpaths=tests",
     "-c", "pyproject.toml",
     "--cov-reset",
     "--cov=src/grizzly_ls",

--- a/grizzly-ls/src/grizzly_ls/server/features/diagnostics.py
+++ b/grizzly-ls/src/grizzly_ls/server/features/diagnostics.py
@@ -240,7 +240,7 @@ def validate_gherkin(
                             start=lsp.Position(line=lineno, character=position),
                             end=lsp.Position(line=lineno, character=len(line)),
                         ),
-                        message=f'scenario tag is invalid, could not find scenario argument',
+                        message='Scenario tag is invalid, could not find scenario argument',
                         severity=lsp.DiagnosticSeverity.Error,
                         source=ls.__class__.__name__,
                     )
@@ -253,7 +253,7 @@ def validate_gherkin(
                             start=lsp.Position(line=lineno, character=position),
                             end=lsp.Position(line=lineno, character=len(line)),
                         ),
-                        message=f'scenario tag is invalid, could not find feature argument',
+                        message='Scenario tag is invalid, could not find feature argument',
                         severity=lsp.DiagnosticSeverity.Error,
                         source=ls.__class__.__name__,
                     )
@@ -298,7 +298,7 @@ def validate_gherkin(
 
                 try:
                     feature = parse_feature(
-                        feature_file.read_text(),
+                        feature_file.read_text(encoding='utf-8'),
                         language=None,
                         filename=feature_file.as_posix(),
                     )
@@ -362,7 +362,7 @@ def validate_gherkin(
                                     character=arg_feature.end + position + 2,
                                 ),
                             ),
-                            message=f'Feature argument is empty',
+                            message='Feature argument is empty',
                             severity=lsp.DiagnosticSeverity.Warning,
                             source=ls.__class__.__name__,
                         )
@@ -381,7 +381,7 @@ def validate_gherkin(
                                     character=arg_scenario.end + position + 2,
                                 ),
                             ),
-                            message=f'Scenario argument is empty',
+                            message='Scenario argument is empty',
                             severity=lsp.DiagnosticSeverity.Warning,
                             source=ls.__class__.__name__,
                         )

--- a/grizzly-ls/tests/unit/server/feature/test_diagnostics.py
+++ b/grizzly-ls/tests/unit/server/feature/test_diagnostics.py
@@ -1,7 +1,7 @@
 from typing import Any
+from itertools import product
 
 from pygls.workspace import TextDocument
-from pytest_mock import MockerFixture
 from lsprotocol import types as lsp
 
 from grizzly_ls.server.features.diagnostics import validate_gherkin
@@ -10,7 +10,7 @@ from grizzly_ls.model import Step
 from tests.fixtures import LspFixture
 
 
-def test_validate_gherkin(lsp_fixture: LspFixture, mocker: MockerFixture) -> None:
+def test_validate_gherkin(lsp_fixture: LspFixture) -> None:
     ls = lsp_fixture.server
 
     ls.language = 'en'
@@ -182,12 +182,33 @@ Feature:
     assert diagnostic.data is None
     # // -->
 
+    # <!-- freetext marker not closed
+    ls.language = 'en'
+    text_document = TextDocument(
+        'file://test.feature',
+        '''# language: en
+Feature:
+    """
+    this is just a comment
+    Scenario: test
+        Then this step actually exists!
+''',
+    )
+
+    diagnostics = validate_gherkin(ls, text_document)
+
+    diagnostic = next(iter(diagnostics))
+
+    assert diagnostic.message == 'Freetext marker is not closed'
+    assert diagnostic.severity == lsp.DiagnosticSeverity.Error
+    # // -->
+
     # <!-- "complex" document with no errors
-    try:
-        ls.language = 'sv'
-        text_document = TextDocument(
-            'file://test.feature',
-            '''# language: sv
+    feature_file = lsp_fixture.datadir / 'features' / 'test.feature'
+    included_feature_file = lsp_fixture.datadir / 'features' / 'hello.feature'
+
+    feature_file.write_text(
+        '''# language: sv
     # testspecifikation: https://test.nu/specifikation/T01
     Egenskap: T01
         """
@@ -207,8 +228,40 @@ Feature:
             """
 
             Så producera ett dokument i formatet "json"
-    ''',
-        )
+
+        Scenario: inkluderat-1
+            {% scenario "hello" feature="./hello.feature" %}
+
+        Scenario: inkluderat-2
+            {% scenario "world" "./hello.feature" %}
+
+        Scenario: inkluderat-3
+            {% scenario scenario="foo", feature="./hello.feature" %}
+
+        Scenario: inkluderat-4
+            {%  scenario  scenario="bar" ,   "./hello.feature" %}
+    '''
+    )
+
+    included_feature_file.write_text(
+        '''# language: sv
+Egenskap: hello
+    Scenario: hello
+        Så producera ett dokument i formatet "xml"
+
+    Scenario: world
+        Så producera ett dokument i formatet "yaml"
+
+    Scenario: foo
+        Så producera en bild i formatet "gif"
+
+    Scenario: bar
+        Så producera en bild i formatet "png"
+'''
+    )
+    try:
+        ls.language = 'sv'
+        text_document = TextDocument(feature_file.as_uri())
 
         ls.steps.update(
             {
@@ -226,4 +279,175 @@ Feature:
         assert diagnostics == []
     finally:
         ls.language = 'en'
+        feature_file.unlink()
+        included_feature_file.unlink()
     # // -->
+
+
+def test_validate_gherkin_scenario_tag(lsp_fixture: LspFixture) -> None:
+    ls = lsp_fixture.server
+
+    feature_file = (
+        lsp_fixture.datadir / 'features' / 'test_validate_gherkin_scenario_tag.feature'
+    )
+
+    try:
+        # <!-- jinja2 expression, not scenario tag -- ignored
+        feature_file.write_text(
+            '''Feature: test scenario tag
+    Scenario: included
+        {% hello %}
+    '''
+        )
+        text_document = TextDocument(feature_file.as_posix())
+
+        diagnostics = validate_gherkin(ls, text_document)
+        assert diagnostics == []
+        # // -->
+
+        # <!-- scenario tag, no arguments
+        feature_file.write_text(
+            '''Feature: test scenario tag
+    Scenario: included
+        {% scenario %}
+    '''
+        )
+        text_document = TextDocument(feature_file.as_posix())
+
+        diagnostics = validate_gherkin(ls, text_document)
+        assert len(diagnostics) == 2
+        diagnostic = diagnostics[0]
+        assert (
+            diagnostic.message
+            == 'scenario tag is invalid, could not find scenario argument'
+        )
+        assert str(diagnostic.range) == '2:8-2:22'
+        assert diagnostic.severity == lsp.DiagnosticSeverity.Error
+
+        diagnostic = diagnostics[1]
+        assert (
+            diagnostic.message
+            == 'scenario tag is invalid, could not find feature argument'
+        )
+        assert str(diagnostic.range) == '2:8-2:22'
+        assert diagnostic.severity == lsp.DiagnosticSeverity.Error
+        # // -->
+
+        # <!-- missing feature argument, scenario argument both as positional and named
+        for argument in ['"foo"', 'scenario="foo"']:
+            feature_file.write_text(
+                f'''Feature: test scenario tag
+    Scenario: included
+        {{% scenario {argument} %}}
+    '''
+            )
+            text_document = TextDocument(feature_file.as_posix())
+
+            diagnostics = validate_gherkin(ls, text_document)
+            assert len(diagnostics) == 1
+            diagnostic = diagnostics[0]
+            assert (
+                diagnostic.message
+                == 'scenario tag is invalid, could not find feature argument'
+            )
+            end = len(argument) + 21 + 2
+            assert str(diagnostic.range) == f'2:8-2:{end}'
+            assert diagnostic.severity == lsp.DiagnosticSeverity.Error
+        # // -->
+
+        # <!-- specified feature file that does not exist
+        for arg_scenario, arg_feature in product(
+            ['"foo"', 'scenario="foo"'],
+            [
+                '"./test_validate_gherkin_scenario_tag_include.feature"',
+                'feature="./test_validate_gherkin_scenario_tag_include.feature"',
+            ],
+        ):
+            for prefix in [None, (lsp_fixture.datadir / 'features').as_posix()]:
+                if prefix is not None:
+                    arg_feature = arg_feature.replace('./', f'{prefix}/')
+
+                feature_file.write_text(
+                    f'''Feature: test scenario tag
+        Scenario: included
+            {{% scenario {arg_scenario}, {arg_feature} %}}
+        '''
+                )
+                text_document = TextDocument(feature_file.as_posix())
+
+                diagnostics = validate_gherkin(ls, text_document)
+
+                assert len(diagnostics) == 1
+
+                diagnostic = diagnostics[0]
+
+                _, feature_file_name, _ = arg_feature.split('"', 3)
+
+                assert (
+                    diagnostic.message
+                    == f'Included feature file "{feature_file_name}" does not exist'
+                )
+
+                included_feature_file = (
+                    lsp_fixture.datadir
+                    / 'features'
+                    / 'test_validate_gherkin_scenario_tag_include.feature'
+                )
+
+                try:
+                    included_feature_file.touch()
+
+                    diagnostics = validate_gherkin(ls, text_document)
+                    diagnostic = next(iter(diagnostics))
+
+                    assert (
+                        diagnostic.message
+                        == f'Included feature file "{feature_file_name}" does not have any scenarios'
+                    )
+
+                    included_feature_file.write_text('''Egenskap: test''')
+
+                    diagnostics = validate_gherkin(ls, text_document)
+                    diagnostic = next(iter(diagnostics))
+
+                    assert (
+                        diagnostic.message
+                        == f'Parser failure in state init\nNo feature found.'
+                    )
+
+                    included_feature_file.write_text('''Feature: test''')
+
+                    diagnostics = validate_gherkin(ls, text_document)
+                    diagnostic = next(iter(diagnostics))
+
+                    assert (
+                        diagnostic.message
+                        == f'Scenario "foo" does not exist in included feature "{feature_file_name}"'
+                    )
+
+                    included_feature_file.write_text(
+                        '''Feature: test
+    Scenario: foo'''
+                    )
+
+                    diagnostics = validate_gherkin(ls, text_document)
+                    diagnostic = next(iter(diagnostics))
+
+                    assert (
+                        diagnostic.message
+                        == f'Scenario "foo" in "{feature_file_name}" does not have any steps'
+                    )
+
+                    included_feature_file.write_text(
+                        '''Feature: test
+    Scenario: foo
+        Given a step expression'''
+                    )
+
+                    diagnostics = validate_gherkin(ls, text_document)
+                    assert len(diagnostics) == 0
+                finally:
+                    included_feature_file.unlink()
+        # // -->
+    finally:
+        feature_file.unlink()

--- a/grizzly-ls/tests/unit/server/feature/test_diagnostics.py
+++ b/grizzly-ls/tests/unit/server/feature/test_diagnostics.py
@@ -333,6 +333,28 @@ def test_validate_gherkin_scenario_tag(lsp_fixture: LspFixture) -> None:
         assert diagnostic.severity == lsp.DiagnosticSeverity.Error
         # // -->
 
+        # <!-- empty scenario and feature arguments
+        feature_file.write_text(
+            '''Feature: test scenario tag
+    Scenario: included
+        {% scenario "", feature="" %}
+    '''
+        )
+        text_document = TextDocument(feature_file.as_posix())
+
+        diagnostics = validate_gherkin(ls, text_document)
+        assert len(diagnostics) == 2
+        diagnostic = diagnostics[0]
+        assert diagnostic.message == 'Feature argument is empty'
+        assert str(diagnostic.range) == '2:33-2:33'
+        assert diagnostic.severity == lsp.DiagnosticSeverity.Warning
+
+        diagnostic = diagnostics[1]
+        assert diagnostic.message == 'Scenario argument is empty'
+        assert str(diagnostic.range) == '2:21-2:21'
+        assert diagnostic.severity == lsp.DiagnosticSeverity.Warning
+        # // -->
+
         # <!-- missing feature argument, scenario argument both as positional and named
         for argument in ['"foo"', 'scenario="foo"']:
             feature_file.write_text(

--- a/grizzly-ls/tests/unit/server/feature/test_diagnostics.py
+++ b/grizzly-ls/tests/unit/server/feature/test_diagnostics.py
@@ -240,7 +240,8 @@ Feature:
 
         Scenario: inkluderat-4
             {%  scenario  scenario="bar" ,   "./hello.feature" %}
-    '''
+    ''',
+        encoding='utf-8',
     )
 
     included_feature_file.write_text(
@@ -257,7 +258,8 @@ Egenskap: hello
 
     Scenario: bar
         Så producera en bild i formatet "png"
-'''
+    ''',
+        encoding='utf-8',
     )
     try:
         ls.language = 'sv'
@@ -297,7 +299,8 @@ def test_validate_gherkin_scenario_tag(lsp_fixture: LspFixture) -> None:
             '''Feature: test scenario tag
     Scenario: included
         {% hello %}
-    '''
+    ''',
+            encoding='utf-8',
         )
         text_document = TextDocument(feature_file.as_posix())
 
@@ -310,7 +313,8 @@ def test_validate_gherkin_scenario_tag(lsp_fixture: LspFixture) -> None:
             '''Feature: test scenario tag
     Scenario: included
         {% scenario %}
-    '''
+    ''',
+            encoding='utf-8',
         )
         text_document = TextDocument(feature_file.as_posix())
 
@@ -319,7 +323,7 @@ def test_validate_gherkin_scenario_tag(lsp_fixture: LspFixture) -> None:
         diagnostic = diagnostics[0]
         assert (
             diagnostic.message
-            == 'scenario tag is invalid, could not find scenario argument'
+            == 'Scenario tag is invalid, could not find scenario argument'
         )
         assert str(diagnostic.range) == '2:8-2:22'
         assert diagnostic.severity == lsp.DiagnosticSeverity.Error
@@ -327,7 +331,7 @@ def test_validate_gherkin_scenario_tag(lsp_fixture: LspFixture) -> None:
         diagnostic = diagnostics[1]
         assert (
             diagnostic.message
-            == 'scenario tag is invalid, could not find feature argument'
+            == 'Scenario tag is invalid, could not find feature argument'
         )
         assert str(diagnostic.range) == '2:8-2:22'
         assert diagnostic.severity == lsp.DiagnosticSeverity.Error
@@ -338,7 +342,8 @@ def test_validate_gherkin_scenario_tag(lsp_fixture: LspFixture) -> None:
             '''Feature: test scenario tag
     Scenario: included
         {% scenario "", feature="" %}
-    '''
+    ''',
+            encoding='utf-8',
         )
         text_document = TextDocument(feature_file.as_posix())
 
@@ -361,7 +366,8 @@ def test_validate_gherkin_scenario_tag(lsp_fixture: LspFixture) -> None:
                 f'''Feature: test scenario tag
     Scenario: included
         {{% scenario {argument} %}}
-    '''
+    ''',
+                encoding='utf-8',
             )
             text_document = TextDocument(feature_file.as_posix())
 
@@ -370,7 +376,7 @@ def test_validate_gherkin_scenario_tag(lsp_fixture: LspFixture) -> None:
             diagnostic = diagnostics[0]
             assert (
                 diagnostic.message
-                == 'scenario tag is invalid, could not find feature argument'
+                == 'Scenario tag is invalid, could not find feature argument'
             )
             end = len(argument) + 21 + 2
             assert str(diagnostic.range) == f'2:8-2:{end}'
@@ -393,7 +399,8 @@ def test_validate_gherkin_scenario_tag(lsp_fixture: LspFixture) -> None:
                     f'''Feature: test scenario tag
         Scenario: included
             {{% scenario {arg_scenario}, {arg_feature} %}}
-        '''
+        ''',
+                    encoding='utf-8',
                 )
                 text_document = TextDocument(feature_file.as_posix())
 
@@ -427,17 +434,21 @@ def test_validate_gherkin_scenario_tag(lsp_fixture: LspFixture) -> None:
                         == f'Included feature file "{feature_file_name}" does not have any scenarios'
                     )
 
-                    included_feature_file.write_text('''Egenskap: test''')
+                    included_feature_file.write_text(
+                        '''Egenskap: test''', encoding='utf-8'
+                    )
 
                     diagnostics = validate_gherkin(ls, text_document)
                     diagnostic = next(iter(diagnostics))
 
                     assert (
                         diagnostic.message
-                        == f'Parser failure in state init\nNo feature found.'
+                        == 'Parser failure in state init\nNo feature found.'
                     )
 
-                    included_feature_file.write_text('''Feature: test''')
+                    included_feature_file.write_text(
+                        '''Feature: test''', encoding='utf-8'
+                    )
 
                     diagnostics = validate_gherkin(ls, text_document)
                     diagnostic = next(iter(diagnostics))
@@ -449,7 +460,8 @@ def test_validate_gherkin_scenario_tag(lsp_fixture: LspFixture) -> None:
 
                     included_feature_file.write_text(
                         '''Feature: test
-    Scenario: foo'''
+    Scenario: foo''',
+                        encoding='utf-8',
                     )
 
                     diagnostics = validate_gherkin(ls, text_document)
@@ -463,7 +475,8 @@ def test_validate_gherkin_scenario_tag(lsp_fixture: LspFixture) -> None:
                     included_feature_file.write_text(
                         '''Feature: test
     Scenario: foo
-        Given a step expression'''
+        Given a step expression''',
+                        encoding='utf-8',
                     )
 
                     diagnostics = validate_gherkin(ls, text_document)

--- a/grizzly-ls/types/behave/model.pyi
+++ b/grizzly-ls/types/behave/model.pyi
@@ -1,1 +1,12 @@
-class Feature: ...
+from typing import List
+
+class Step: ...
+
+class Scenario:
+    name: str
+    steps: List[Step]
+    ...
+
+class Feature:
+    scenarios: List[Scenario]
+    ...

--- a/grizzly-ls/types/behave/parser.pyi
+++ b/grizzly-ls/types/behave/parser.pyi
@@ -4,7 +4,7 @@ from behave.model import Feature
 
 def parse_feature(
     data: str, language: Optional[str], filename: Optional[str]
-) -> Feature: ...
+) -> Optional[Feature]: ...
 
 class ParserError(Exception):
     line: Optional[int]


### PR DESCRIPTION
implemented in Biometria-se/grizzly#295

supports:
- diagnostics, valid tag and values
- completion, very simple, suggest `scenario "", feature=""` when `{%` is the "trigger" characters
- definition, to be able to ctrl + click `feature` argument in tag expression